### PR TITLE
force snfoundry version to v0.21.0 to fix new release

### DIFF
--- a/.github/workflows/snfoundry.yml
+++ b/.github/workflows/snfoundry.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Install snfoundry
         run: curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh
       - name: Install snforge and sncast
-        run: snfoundryup -v v0.21.0 && snforge --version
+        run: snfoundryup -v 0.21.0 && snforge --version
       - name: Run tests
         run: scarb test


### PR DESCRIPTION
## Summary

Starknet Foundry v0.22.0 is out and makes the test fails. The reason is documented in the `CHANGELOG.md` file and says

- `deploy` / `deploy_at` now additionally return the constructor return data via `SyscallResult<(ContractAddress, Span<felt252>)>`
- `declare` returns `Result<ContractClass, Array<felt252>>` instead of `ContractClass`

## Changes

For now, we will "just" fix the Starknet Foundry version to v0.21.0 before we fix change the test to address the changes.

## Checklist:

- [ ] Link the associated issue
- [x] Perform a self-review of the code
- [x] Rebase to the head of the `develop` branch from 0xknow/starknet-modular-account
- [x] Document the changes in code
- [x] Make sure the code is properly formatted by running `scarb fmt`
- [x] Add unit tests with starknet foundry
- [x] Add integration tests with starknet.js and jest
- [x] Pass all the tests
