### PR TITLE
add 2nd argument to simple account

### DIFF
--- a/__integration__/simple_account.test.ts
+++ b/__integration__/simple_account.test.ts
@@ -1,0 +1,57 @@
+import { deployClass, classHash } from "./class";
+import { accountAddress, deployAccount } from "./simple_account";
+import { config, testAccount, provider, type AccountConfig } from "./utils";
+import { Account } from "starknet";
+import { timeout } from "./constants";
+
+describe("simple account management", () => {
+  let env: string;
+  let testAccounts: Account[];
+  let targetAccounts: Account[];
+  let targetAccountConfigs: AccountConfig[];
+  beforeAll(() => {
+    env = "devnet";
+    const conf = config(env);
+    testAccounts = [testAccount(0, conf), testAccount(1, conf)];
+    targetAccountConfigs = [
+      {
+        classHash: classHash("SimpleAccount"),
+        address: accountAddress(
+          "SimpleAccount",
+          conf.accounts[0].publicKey,
+          "0x10"
+        ),
+        publicKey: conf.accounts[0].publicKey,
+        privateKey: conf.accounts[0].privateKey,
+      },
+    ];
+    targetAccounts = [
+      new Account(
+        provider(conf.providerURL),
+        targetAccountConfigs[0].address,
+        targetAccountConfigs[0].privateKey
+      ),
+    ];
+  });
+
+  it(
+    "deploys the Account class",
+    async () => {
+      const a = testAccounts[0];
+      const c = await deployClass(a, "SimpleAccount");
+      expect(c.classHash).toEqual(classHash("SimpleAccount"));
+    },
+    timeout
+  );
+
+  it(
+    "deploys the account contract",
+    async () => {
+      const a = testAccounts[0];
+      const publicKey = targetAccountConfigs[0].publicKey;
+      const c = await deployAccount(a, "SimpleAccount", publicKey, "0x10");
+      expect(c).toEqual(accountAddress("SimpleAccount", publicKey, "0x10"));
+    },
+    timeout
+  );
+});

--- a/__integration__/simple_account.ts
+++ b/__integration__/simple_account.ts
@@ -1,0 +1,60 @@
+import { ethTransfer } from "./utils";
+import { classHash } from "./class";
+import { Call, CallData, hash, Account, Contract } from "starknet";
+import { initial_EthTransfer } from "./constants";
+
+// accountAddress compute the account address from the account public key.
+export const accountAddress = (
+  name: string = "SimpleAccount",
+  publicKey: string,
+  more: string,
+): string => {
+  const AccountClassHash = classHash(name);
+  const calldata = [publicKey, more];
+  return hash.calculateContractAddressFromHash(
+    publicKey,
+    AccountClassHash,
+    calldata,
+    0
+  );
+};
+
+export const deployAccount = async (
+  deployerAccount: Account,
+  name: string = "SimpleAccount",
+  publicKey: string,
+  more: string,
+) => {
+  const computedClassHash = classHash(name);
+  const AccountAddress = accountAddress(name, publicKey, more);
+  try {
+    const deployedClassHash =
+      await deployerAccount.getClassHashAt(AccountAddress);
+    if (deployedClassHash !== computedClassHash) {
+      throw new Error(
+        `Class mismatch: expect ${computedClassHash}, got ${deployedClassHash}`
+      );
+    }
+    return AccountAddress;
+  } catch (e) {}
+  const tx = await ethTransfer(
+    deployerAccount,
+    AccountAddress,
+    initial_EthTransfer
+  );
+  if (!tx.isSuccess()) {
+    throw new Error(`Failed to transfer eth to account: ${tx.statusReceipt}`);
+  }
+  const calldata = [publicKey, more];
+  const { transaction_hash } =
+    await deployerAccount.deployAccount({
+      classHash: computedClassHash,
+      constructorCalldata: calldata,
+      addressSalt: publicKey,
+    });
+  const txReceipt = await deployerAccount.waitForTransaction(transaction_hash);
+  if (!txReceipt.isSuccess()) {
+    throw new Error(`Failed to deploy account: ${txReceipt.status}`);
+  }
+  return AccountAddress;
+};

--- a/src/presets.cairo
+++ b/src/presets.cairo
@@ -2,5 +2,4 @@ mod smartr_account;
 mod core_validator;
 mod simple_validator;
 mod sessionkey_validator;
-mod simple_account;
 mod helpers;

--- a/src/presets/helpers.cairo
+++ b/src/presets/helpers.cairo
@@ -3,3 +3,4 @@ mod failed_account;
 mod swap_router;
 mod token_a;
 mod token_b;
+mod simple_account;


### PR DESCRIPTION
## Summary

Add a 2nd parameter to the `SimpleAccount` deployment with the test to experiment the removal of the hard-coded core validator in the modular account

## Checklist:

- [ ] Link the associated issue
- [x] Perform a self-review of the code
- [x] Rebase to the head of the `develop` branch from 0xknow/starknet-modular-account
- [x] Document the changes in code
- [x] Make sure the code is properly formatted by running `scarb fmt`
- [x] Add unit tests with starknet foundry
- [x] Add integration tests with starknet.js and jest
- [x] Pass all the tests
