### PR TITLE
rename sdk account functions in camel case

### DIFF
--- a/sdks/starknet-account/src/module.test.ts
+++ b/sdks/starknet-account/src/module.test.ts
@@ -69,7 +69,7 @@ describe("module management", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(1);
       expect(`0x${c[0].toString(16)}`).toEqual(conf.accounts[0].publicKey);
@@ -83,7 +83,7 @@ describe("module management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module("0x0");
+      const output = await smartrAccount.isModule("0x0");
       expect(output).toBe(false);
     },
     default_timeout
@@ -106,7 +106,7 @@ describe("module management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const { transaction_hash } = await smartrAccount.add_module(
+      const { transaction_hash } = await smartrAccount.addModule(
         classHash("SimpleValidator")
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -121,7 +121,7 @@ describe("module management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module(
+      const output = await smartrAccount.isModule(
         classHash("SimpleValidator")
       );
       expect(output).toBe(true);
@@ -136,7 +136,7 @@ describe("module management", () => {
         throw new Error("SmartrAccount is not deployed");
       }
       try {
-        await smartrAccount.add_module(classHash("SimpleValidator"));
+        await smartrAccount.addModule(classHash("SimpleValidator"));
         expect(true).toBe(false);
       } catch (e) {
         expect(e).toBeDefined();
@@ -151,7 +151,7 @@ describe("module management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const { transaction_hash } = await smartrAccount.remove_module(
+      const { transaction_hash } = await smartrAccount.removeModule(
         classHash("SimpleValidator")
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -166,7 +166,7 @@ describe("module management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module(
+      const output = await smartrAccount.isModule(
         classHash("SimpleValidator")
       );
       expect(output).toBe(false);

--- a/sdks/starknet-account/src/multisig.test.ts
+++ b/sdks/starknet-account/src/multisig.test.ts
@@ -98,7 +98,7 @@ describe("multiple signature", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(1);
       expect(`0x${c[0].toString(16)}`).toEqual(conf.accounts[0].publicKey);
@@ -109,7 +109,7 @@ describe("multiple signature", () => {
   it(
     "checks the SmartAccount threshhold",
     async () => {
-      const c = await smartrAccount.get_threshold();
+      const c = await smartrAccount.getThreshold();
       expect(c).toEqual(1n);
     },
     default_timeout
@@ -188,7 +188,7 @@ describe("multiple signature", () => {
   it(
     "checks the SmartAccount threshhold",
     async () => {
-      const c = await smartrAccount.get_threshold();
+      const c = await smartrAccount.getThreshold();
       expect(c).toEqual(1n);
     },
     default_timeout
@@ -198,7 +198,7 @@ describe("multiple signature", () => {
     "adds a 2nd public key to the account",
     async () => {
       const conf = config(env);
-      const { transaction_hash } = await smartrAccount.add_public_key(
+      const { transaction_hash } = await smartrAccount.addPublicKey(
         conf.accounts[1].publicKey
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -210,7 +210,7 @@ describe("multiple signature", () => {
   it(
     "checks the new public key with the account",
     async () => {
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(2);
       const conf = config(env);
@@ -288,7 +288,7 @@ describe("multiple signature", () => {
   it(
     "updates the account threshold to 2",
     async () => {
-      const { transaction_hash } = await smartrAccount.set_threshold(2n);
+      const { transaction_hash } = await smartrAccount.setThreshold(2n);
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
     },
@@ -304,7 +304,7 @@ describe("multiple signature", () => {
         conf.accounts[0].privateKey,
         conf.accounts[1].privateKey,
       ]);
-      const { transaction_hash } = await altSmartrAccount.add_public_key(
+      const { transaction_hash } = await altSmartrAccount.addPublicKey(
         conf.accounts[2].publicKey
       );
       const receipt =
@@ -317,7 +317,7 @@ describe("multiple signature", () => {
   it(
     "checks the new public key with the account",
     async () => {
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(3);
       const conf = config(env);
@@ -413,7 +413,7 @@ describe("multiple signature", () => {
         conf.accounts[1].privateKey,
         conf.accounts[2].privateKey,
       ]);
-      const { transaction_hash } = await altSmartrAccount.set_threshold(1n);
+      const { transaction_hash } = await altSmartrAccount.setThreshold(1n);
       const receipt =
         await altSmartrAccount.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
@@ -424,7 +424,7 @@ describe("multiple signature", () => {
   it(
     "checks the SmartAccount threshhold is back to 1",
     async () => {
-      const c = await smartrAccount.get_threshold();
+      const c = await smartrAccount.getThreshold();
       expect(c).toEqual(1n);
     },
     default_timeout
@@ -454,7 +454,7 @@ describe("multiple signature", () => {
     "removes the 2nd public key from the account",
     async () => {
       const conf = config(env);
-      const { transaction_hash } = await smartrAccount.remove_public_key(
+      const { transaction_hash } = await smartrAccount.removePublicKey(
         conf.accounts[1].publicKey
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -466,7 +466,7 @@ describe("multiple signature", () => {
   it(
     "checks the public key with the account are 2",
     async () => {
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(2);
       const conf = config(env);
@@ -479,7 +479,7 @@ describe("multiple signature", () => {
     "removes the ex-3rd public key from the account",
     async () => {
       const conf = config(env);
-      const { transaction_hash } = await smartrAccount.remove_public_key(
+      const { transaction_hash } = await smartrAccount.removePublicKey(
         conf.accounts[2].publicKey
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -491,7 +491,7 @@ describe("multiple signature", () => {
   it(
     "checks the public key with the account are 1",
     async () => {
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(1);
       const conf = config(env);

--- a/sdks/starknet-account/src/smartr_account.test.ts
+++ b/sdks/starknet-account/src/smartr_account.test.ts
@@ -98,7 +98,7 @@ describe("account management", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(1);
       expect(`0x${c[0].toString(16)}`).toEqual(conf.accounts[0].publicKey);
@@ -111,7 +111,7 @@ describe("account management", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_threshold();
+      const c = await smartrAccount.getThreshold();
       expect(c).toEqual(1n);
     },
     default_timeout

--- a/sdks/starknet-account/src/smartr_account.ts
+++ b/sdks/starknet-account/src/smartr_account.ts
@@ -267,7 +267,7 @@ export class SmartrAccount extends Account {
    * Retrieves the public keys associated with the SmartrAccount.
    * @returns A promise that resolves to the public keys.
    */
-  async get_public_keys() {
+  async getPublicKeys() {
     const contract = new Contract(SmartrAccountABI, this.address, this).typedv2(
       SmartrAccountABI
     );
@@ -278,7 +278,7 @@ export class SmartrAccount extends Account {
    * Retrieves the threshold value of the SmartrAccount.
    * @returns A promise that resolves to the threshold value.
    */
-  async get_threshold() {
+  async getThreshold() {
     const contract = new Contract(SmartrAccountABI, this.address, this).typedv2(
       SmartrAccountABI
     );
@@ -290,7 +290,7 @@ export class SmartrAccount extends Account {
    * @param new_public_key - The new public key to add.
    * @returns A promise that resolves to the transaction receipt.
    */
-  async add_public_key(new_public_key: string) {
+  async addPublicKey(new_public_key: string) {
     const contract = new Contract(SmartrAccountABI, this.address, this).typedv2(
       SmartrAccountABI
     );
@@ -305,7 +305,7 @@ export class SmartrAccount extends Account {
    * @param old_public_key - The public key to remove.
    * @returns A promise that resolves to the transaction receipt.
    */
-  async remove_public_key(old_public_key: string) {
+  async removePublicKey(old_public_key: string) {
     const contract = new Contract(SmartrAccountABI, this.address, this).typedv2(
       SmartrAccountABI
     );
@@ -320,7 +320,7 @@ export class SmartrAccount extends Account {
    * @param new_threshold - The new threshold value.
    * @returns A promise that resolves to the transaction receipt.
    */
-  async set_threshold(new_threshold: bigint) {
+  async setThreshold(new_threshold: bigint) {
     const contract = new Contract(SmartrAccountABI, this.address, this).typedv2(
       SmartrAccountABI
     );
@@ -330,14 +330,14 @@ export class SmartrAccount extends Account {
     return this.execute(transferCall);
   }
 
-  async is_module(class_hash: string) {
+  async isModule(class_hash: string) {
     const contract = new Contract(SmartrAccountABI, this.address, this).typedv2(
       SmartrAccountABI
     );
     return await contract.is_module(class_hash);
   }
 
-  async add_module(class_hash: string) {
+  async addModule(class_hash: string) {
     const contract = new Contract(SmartrAccountABI, this.address, this).typedv2(
       SmartrAccountABI
     );
@@ -348,7 +348,7 @@ export class SmartrAccount extends Account {
     return await this.execute(transferCall);
   }
 
-  async remove_module(class_hash: string) {
+  async removeModule(class_hash: string) {
     const contract = new Contract(SmartrAccountABI, this.address, this).typedv2(
       SmartrAccountABI
     );

--- a/sdks/starknet-account/src/upgrade.test.ts
+++ b/sdks/starknet-account/src/upgrade.test.ts
@@ -81,7 +81,7 @@ describe("upgrade management", () => {
     "checks the SmartAccount public keys",
     async () => {
       const conf = config(env);
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(1);
       expect(`0x${c[0].toString(16)}`).toEqual(conf.accounts[0].publicKey);

--- a/sdks/starknet-module-sessionkey/src/sessionkey_with_root.test.ts
+++ b/sdks/starknet-module-sessionkey/src/sessionkey_with_root.test.ts
@@ -114,7 +114,7 @@ describe("sessionkey management", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(1);
       expect(`0x${c[0].toString(16)}`).toEqual(conf.accounts[0].publicKey);
@@ -127,7 +127,7 @@ describe("sessionkey management", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_threshold();
+      const c = await smartrAccount.getThreshold();
       expect(c).toEqual(1n);
     },
     default_timeout
@@ -197,7 +197,7 @@ describe("sessionkey management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const { transaction_hash } = await smartrAccount.add_module(
+      const { transaction_hash } = await smartrAccount.addModule(
         classHash("SessionKeyValidator")
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -212,7 +212,7 @@ describe("sessionkey management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module(
+      const output = await smartrAccount.isModule(
         classHash("SessionKeyValidator")
       );
       expect(output).toBe(true);
@@ -360,7 +360,7 @@ describe("sessionkey management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const { transaction_hash } = await smartrAccount.remove_module(
+      const { transaction_hash } = await smartrAccount.removeModule(
         classHash("SessionKeyValidator")
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -375,7 +375,7 @@ describe("sessionkey management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module(
+      const output = await smartrAccount.isModule(
         classHash("SessionKeyValidator")
       );
       expect(output).toBe(false);

--- a/sdks/starknet-module-sessionkey/src/sessionkey_zero_root.test.ts
+++ b/sdks/starknet-module-sessionkey/src/sessionkey_zero_root.test.ts
@@ -113,7 +113,7 @@ describe("sessionkey management", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(1);
       expect(`0x${c[0].toString(16)}`).toEqual(conf.accounts[0].publicKey);
@@ -126,7 +126,7 @@ describe("sessionkey management", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_threshold();
+      const c = await smartrAccount.getThreshold();
       expect(c).toEqual(1n);
     },
     default_timeout
@@ -196,7 +196,7 @@ describe("sessionkey management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const { transaction_hash } = await smartrAccount.add_module(
+      const { transaction_hash } = await smartrAccount.addModule(
         classHash("SessionKeyValidator")
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -211,7 +211,7 @@ describe("sessionkey management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module(
+      const output = await smartrAccount.isModule(
         classHash("SessionKeyValidator")
       );
       expect(output).toBe(true);
@@ -353,7 +353,7 @@ describe("sessionkey management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const { transaction_hash } = await smartrAccount.remove_module(
+      const { transaction_hash } = await smartrAccount.removeModule(
         classHash("SessionKeyValidator")
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -368,7 +368,7 @@ describe("sessionkey management", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module(
+      const output = await smartrAccount.isModule(
         classHash("SessionKeyValidator")
       );
       expect(output).toBe(false);

--- a/sdks/starknet-module-sessionkey/src/swap.test.ts
+++ b/sdks/starknet-module-sessionkey/src/swap.test.ts
@@ -213,7 +213,7 @@ describe("sessionkey swap", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_public_keys();
+      const c = await smartrAccount.getPublicKeys();
       expect(Array.isArray(c)).toBe(true);
       expect(c.length).toEqual(1);
       expect(`0x${c[0].toString(16)}`).toEqual(conf.accounts[0].publicKey);
@@ -226,7 +226,7 @@ describe("sessionkey swap", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await smartrAccount.get_threshold();
+      const c = await smartrAccount.getThreshold();
       expect(c).toEqual(1n);
     },
     default_timeout
@@ -249,7 +249,7 @@ describe("sessionkey swap", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const { transaction_hash } = await smartrAccount.add_module(
+      const { transaction_hash } = await smartrAccount.addModule(
         classHash("SessionKeyValidator")
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -264,7 +264,7 @@ describe("sessionkey swap", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module(
+      const output = await smartrAccount.isModule(
         classHash("SessionKeyValidator")
       );
       expect(output).toBe(true);
@@ -401,7 +401,7 @@ describe("sessionkey swap", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const { transaction_hash } = await smartrAccount.remove_module(
+      const { transaction_hash } = await smartrAccount.removeModule(
         classHash("SessionKeyValidator")
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
@@ -416,7 +416,7 @@ describe("sessionkey swap", () => {
       if (!smartrAccount) {
         throw new Error("SmartrAccount is not deployed");
       }
-      const output = await smartrAccount.is_module(
+      const output = await smartrAccount.isModule(
         classHash("SessionKeyValidator")
       );
       expect(output).toBe(false);


### PR DESCRIPTION
## Summary

rename sdk account functions in camel case to match the typescript practices even if the account functions are actually in snake case.
