### PR TITLE
upgrade openzeppelin cairo-contracts to 0.12

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,8 +3,8 @@ version = 1
 
 [[package]]
 name = "openzeppelin"
-version = "0.11.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.11.0#a83f36b23f1af6e160288962be4a2701c3ecbcda"
+version = "0.12.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.12.0#0697004db74502ce49900edef37331dd03531356"
 
 [[package]]
 name = "smartr"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,7 +7,7 @@ experimental-features = ["negative_impls"]
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.11.0" }
+openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.12.0" }
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.22.0" }
 starknet = "2.6.3"
 

--- a/src/presets/helpers/token_a.cairo
+++ b/src/presets/helpers/token_a.cairo
@@ -4,7 +4,7 @@
 #[starknet::contract]
 mod TokenA {
     use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::token::erc20::ERC20Component;
+    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use openzeppelin::token::erc20::interface;
     use openzeppelin::upgrades::UpgradeableComponent;
     use openzeppelin::upgrades::interface::IUpgradeable;

--- a/src/presets/helpers/token_b.cairo
+++ b/src/presets/helpers/token_b.cairo
@@ -4,7 +4,7 @@
 #[starknet::contract]
 mod TokenB {
     use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::token::erc20::ERC20Component;
+    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use openzeppelin::token::erc20::interface;
     use openzeppelin::upgrades::UpgradeableComponent;
     use openzeppelin::upgrades::interface::IUpgradeable;


### PR DESCRIPTION
## Summary

upgrade openzeppelin cairo-contracts to 0.12

