### PR TITLE
execute module entrypoints from the account

### DIFF
--- a/src/account/account.cairo
+++ b/src/account/account.cairo
@@ -311,6 +311,7 @@ pub mod AccountComponent {
         fn execute_on_module(
             ref self: ComponentState<TContractState>, class_hash: ClassHash, call: Call
         ) -> Array<felt252> {
+            self.assert_only_self();
             let is_module = self.is_module(class_hash);
             assert(is_module, Errors::MODULE_NOT_INSTALLED);
             IConfigureLibraryDispatcher { class_hash }.execute(call)

--- a/src/presets/core_validator.cairo
+++ b/src/presets/core_validator.cairo
@@ -62,7 +62,20 @@ mod CoreValidator {
         }
 
         fn execute(ref self: ContractState, call: Call) -> Array<felt252> {
-            array![]
+            let mut output = ArrayTrait::<felt252>::new();
+            let mut found = false;
+            if call.selector == selector!("add_public_key") {
+                found = true;
+                if call.calldata.len() != 1 {
+                    assert(false, 'Invalid payload');
+                }
+                let key = *call.calldata.at(0);
+                self.account.add_public_key(key);
+            }
+            if !found {
+                assert(false, 'Invalid selector');
+            }
+            output
         }
     }
 }


### PR DESCRIPTION
## Summary

add the infrastructure and example to execute a module entrypoints ,i.e. in a library,  from the account and succeed the associated transaction.
