### PR TITLE
prepare version 0.1.6 with helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-modular-account",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "a modular account for starknet",
   "scripts": {
     "artifacts:artifacts": "cp -R target/dev/smartr_CoreValidator.* target/dev/smartr_SimpleValidator.* target/dev/smartr_SmartrAccount.* target/dev/smartr_SessionKeyValidator.* artifacts/.",

--- a/sdks/__tests__/helpers/package.json
+++ b/sdks/__tests__/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-test-helpers",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/account/package.json
+++ b/sdks/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-modular-account",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/module-sessionkey/package.json
+++ b/sdks/module-sessionkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-module-sessionkey",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Add the helpers to version 0.1.6 so that we can write tests that are not part of the repository and easily access Counter/SwapRouter and more.

