### PR TITLE
call Core Validator validate from __validate__

### DIFF
--- a/docs/BIBLIOGRAPHY.md
+++ b/docs/BIBLIOGRAPHY.md
@@ -41,6 +41,8 @@ that suggests the Paymaster is not yet prioritized.
   supports an alpha implementation of the
   [Safe{Core} Protocol](https://forum.safe.global/t/safe-core-protocol-whitepaper/3949)
 - The [Kernel Smart Contract](https://github.com/zerodevapp/kernel)
+- The [RIP 7560](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7560.md)
+  that is a proposal to make ERC 4337 mandatory for rollups.
 
 ## Module Registry
 
@@ -69,3 +71,10 @@ have a look at existing implementations like:
 - [Zodiac Modules](https://github.com/gnosisguild/zodiac)
 - [A list of modules and resources by Rhinestone](https://github.com/rhinestonewtf/awesome-modular-accounts)
 - [Safe Hackathon Ideas](https://safe-global.notion.site/d75c813772f54528990a9b5c2f5cb375?v=96a818baabe242e3ad25aad66722b2bb)
+
+## Other resources
+
+You might also want to check:
+
+- [Notes on the Account Abstraction roadmap](https://notes.ethereum.org/@yoav/AA-roadmap-May-2024)
+- The Awesome [AA list of projects](https://github.com/4337Mafia/awesome-account-abstraction)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,6 +37,11 @@ are the following:
 
 - is_valid_signature should support `Array<felt252>` and not `felt252` as a
   first parameter for the account and the module
+- the __validate_deploy__ and __validate_declare__ use the is_valid_signature
+  of the core module with a transaction_hash computed by the network. This is
+  a concern because the core validator has to use the same hash computation
+  as the network to validate the account deployment. TL;DR: We will have to
+  extend the interface of the core validator to support other signature schems.
 - Version the contracts for both accounts and modules and maintain a
   compatibility matrix
 - Improve the upgrade management with the help of the bootstrap experiment.


### PR DESCRIPTION
## Summary

Up to now, that was the `is_valid_signature` of the core validator being used with the hash computed by the network. That is a concern because it does not enable we rely on another hash algorithm. This change that will grant access to the calls from the Core Validator enable to compute an alternate hash that is not the one from the network. We know we have the same issue with __validate_deploy__ and __validate_declare__ and we know:
- it will have to be fixed before we implement an alternate hash for those
- we will probably need to extend the interface of the core validator to enable this to be fixed

This has been added to the ROADMAP.md file.

This PR fixes #136
