### PR TITLE
change hash to Array<felt252> in is_valid_signature

### DIFF
--- a/docs/MODULE-STARK-VALIDATOR.md
+++ b/docs/MODULE-STARK-VALIDATOR.md
@@ -44,7 +44,7 @@ The interface looks like this:
 ```rust
 #[starknet::interface]
 pub trait ICoreValidator<TState> {
-    fn is_valid_signature(self: @TState, hash: felt252, signature: Array<felt252>) -> felt252;
+    fn is_valid_signature(self: @TState, hash: Hash<felt252>, signature: Array<felt252>) -> felt252;
     fn initialize(ref self: TState, public_key: felt252);
 }
 ```

--- a/docs/MODULES-DEVELOPMENT.md
+++ b/docs/MODULES-DEVELOPMENT.md
@@ -47,7 +47,7 @@ the account public key when the accounted is created the first time
 ```rust
 #[starknet::interface]
 pub trait ICoreValidator<TState> {
-    fn is_valid_signature(self: @TState, hash: felt252, signature: Array<felt252>) -> felt252;
+    fn is_valid_signature(self: @TState, hash: Array<felt252>, signature: Array<felt252>) -> felt252;
     fn initialize(ref self: TState, public_key: felt252);
 }
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,8 +35,6 @@ that have been identified and need to be addressed. Most of them are
 implementation details bit some of them might impact your usage. Those issues
 are the following:
 
-- is_valid_signature should support `Array<felt252>` and not `felt252` as a
-  first parameter for the account and the module
 - the __validate_deploy__ and __validate_declare__ use the is_valid_signature
   method of the core module with a transaction_hash computed by the network.
   This might have to be revisited or not. As a matter of fact, addresses of the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,10 +38,10 @@ are the following:
 - is_valid_signature should support `Array<felt252>` and not `felt252` as a
   first parameter for the account and the module
 - the __validate_deploy__ and __validate_declare__ use the is_valid_signature
-  of the core module with a transaction_hash computed by the network. This is
-  a concern because the core validator has to use the same hash computation
-  as the network to validate the account deployment. TL;DR: We will have to
-  extend the interface of the core validator to support other signature schems.
+  method of the core module with a transaction_hash computed by the network.
+  This might have to be revisited or not. As a matter of fact, addresses of the
+  account and contract are based on the pedersen hash anyway so why not simply
+  sign those. A hunch is that somehow the pedersen hash is useful in that case.
 - Version the contracts for both accounts and modules and maintain a
   compatibility matrix
 - Improve the upgrade management with the help of the bootstrap experiment.

--- a/src/account/smartraccount.cairo
+++ b/src/account/smartraccount.cairo
@@ -20,8 +20,6 @@ mod SmartrAccount {
     #[abi(embed_v0)]
     impl DeployableImpl = AccountComponent::DeployableImpl<ContractState>;
     #[abi(embed_v0)]
-    impl SRC6CamelOnlyImpl = AccountComponent::SRC6CamelOnlyImpl<ContractState>;
-    #[abi(embed_v0)]
     impl ModuleImpl = AccountComponent::ModuleImpl<ContractState>;
 
     impl AccountInternalImpl = AccountComponent::InternalImpl<ContractState>;

--- a/src/component.cairo
+++ b/src/component.cairo
@@ -3,7 +3,6 @@ pub use account::AccountComponent;
 pub use account::ISRC6;
 pub use account::IDeclarer;
 pub use account::IDeployable;
-pub use account::ISRC6CamelOnly;
 pub use account::IModule;
 pub use account::{IModuleDispatcherTrait, IModuleDispatcher};
 mod validator;

--- a/src/component/validator.cairo
+++ b/src/component/validator.cairo
@@ -9,7 +9,7 @@ pub const IValidator_ID: felt252 =
 
 #[starknet::interface]
 pub trait ICoreValidator<TState> {
-    fn is_valid_signature(self: @TState, hash: felt252, signature: Array<felt252>) -> felt252;
+    fn is_valid_signature(self: @TState, hash: Array<felt252>, signature: Array<felt252>) -> felt252;
     fn initialize(ref self: TState, public_key: felt252);
 }
 

--- a/src/helpers/bootstrap_account.cairo
+++ b/src/helpers/bootstrap_account.cairo
@@ -31,8 +31,6 @@ mod BootstrapAccount {
     impl DeclarerImpl = AccountComponent::DeclarerImpl<ContractState>;
     #[abi(embed_v0)]
     impl PublicKeyImpl = AccountComponent::PublicKeyImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl SRC6CamelOnlyImpl = AccountComponent::SRC6CamelOnlyImpl<ContractState>;
 
     impl AccountInternalImpl = AccountComponent::InternalImpl<ContractState>;
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;

--- a/src/helpers/failed_account.cairo
+++ b/src/helpers/failed_account.cairo
@@ -74,10 +74,6 @@ mod FailedAccount {
     #[abi(embed_v0)]
     impl PublicKeyImpl = AccountComponent::PublicKeyImpl<ContractState>;
     #[abi(embed_v0)]
-    impl PublicKeyCamelImpl = AccountComponent::PublicKeyCamelImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl SRC6CamelOnlyImpl = AccountComponent::SRC6CamelOnlyImpl<ContractState>;
-    #[abi(embed_v0)]
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     impl SRC5InternalImpl = SRC5Component::InternalImpl<ContractState>;

--- a/src/helpers/simple_account.cairo
+++ b/src/helpers/simple_account.cairo
@@ -30,8 +30,6 @@ mod SimpleAccount {
     impl DeclarerImpl = AccountComponent::DeclarerImpl<ContractState>;
     #[abi(embed_v0)]
     impl PublicKeyImpl = AccountComponent::PublicKeyImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl SRC6CamelOnlyImpl = AccountComponent::SRC6CamelOnlyImpl<ContractState>;
 
     impl AccountInternalImpl = AccountComponent::InternalImpl<ContractState>;
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;

--- a/src/modules/sessionkeyvalidator/sessionkeyvalidator.cairo
+++ b/src/modules/sessionkeyvalidator/sessionkeyvalidator.cairo
@@ -162,7 +162,7 @@ mod SessionKeyValidator {
             assert(!is_disabled, Errors::DISABLED_SESSION);
 
             ICoreValidatorLibraryDispatcher { class_hash: grantor_class }
-                .is_valid_signature(auth_hash, signature)
+                .is_valid_signature(array![auth_hash], signature)
         }
     }
 

--- a/src/modules/starkvalidator/starkvalidator.cairo
+++ b/src/modules/starkvalidator/starkvalidator.cairo
@@ -36,7 +36,7 @@ mod StarkValidator {
     pub impl ValidatorImpl of IValidator<ContractState> {
         fn validate(self: @ContractState, grantor_class: ClassHash, calls: Array<Call>) -> felt252 {
           let tx_info = get_tx_info().unbox();
-          let tx_hash = tx_info.transaction_hash;
+          let tx_hash = array![tx_info.transaction_hash];
           let signature = tx_info.signature;
           let signature_len = signature.len();
           let mut i: usize = 0;
@@ -53,9 +53,13 @@ mod StarkValidator {
     pub impl CoreValidator of ICoreValidator<ContractState> {
         /// Verifies that the given signature is valid for the given hash.
         fn is_valid_signature(
-            self: @ContractState, hash: felt252, signature: Array<felt252>
+            self: @ContractState, hash: Array<felt252>, signature: Array<felt252>
         ) -> felt252 {
-            if self._is_valid_signature(hash, signature.span()) {
+            if signature.len() != 1 {
+                return 0;
+            }
+            let vhash = *hash.at(0);
+            if self._is_valid_signature(vhash, signature.span()) {
                 starknet::VALIDATED
             } else {
                 0


### PR DESCRIPTION
## Summary

The goal of this PR is to change the interface of both the account and validator for `is_valid_signature` so that the has can be longer than just one felt252. This is mandatory to support other hashing algorithme than just the default one.

If fixes #137

