### PR TITLE
add tests to @0xknwn/starknet-test-helpers to show both txn v1/v2 and v3

### DIFF
--- a/.env.template.json
+++ b/.env.template.json
@@ -16,7 +16,7 @@
     {
       "address": "0x49dfb8ce986e21d354ac93ea65e6a11f639c1934ea253e5ff14ca62eca0f38e",
       "privateKey": "0xa20a02f0ac53692d144b20cb371a60d7",
-      "publicKey": "0xb8fd4ddd415902d96f61b7ad201022d495997c2dff8eb9e0eb86253e30fabc"
+      "publicKey": "0xb8fd4ddd415902d96f61b7ad201022d495997c2dff8eb9e0eb86253e30fabc",
       "defaultTransactionVersion": "0x3"
     }
   ]

--- a/.env.template.json
+++ b/.env.template.json
@@ -4,17 +4,20 @@
     {
       "address": "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691",
       "privateKey": "0x71d7bb07b9a64f6f78ac4c816aff4da9",
-      "publicKey": "0x39d9e6ce352ad4530a0ef5d5a18fd3303c3606a7fa6ac5b620020ad681cc33b"
+      "publicKey": "0x39d9e6ce352ad4530a0ef5d5a18fd3303c3606a7fa6ac5b620020ad681cc33b",
+      "defaultTransactionVersion": "0x2"
     },
     {
       "address": "0x78662e7352d062084b0010068b99288486c2d8b914f6e2a55ce945f8792c8b1",
       "privateKey": "0xe1406455b7d66b1690803be066cbe5e",
-      "publicKey": "0x7a1bb2744a7dd29bffd44341dbd78008adb4bc11733601e7eddff322ada9cb"
+      "publicKey": "0x7a1bb2744a7dd29bffd44341dbd78008adb4bc11733601e7eddff322ada9cb",
+      "defaultTransactionVersion": "0x3"
     },
     {
       "address": "0x49dfb8ce986e21d354ac93ea65e6a11f639c1934ea253e5ff14ca62eca0f38e",
       "privateKey": "0xa20a02f0ac53692d144b20cb371a60d7",
       "publicKey": "0xb8fd4ddd415902d96f61b7ad201022d495997c2dff8eb9e0eb86253e30fabc"
+      "defaultTransactionVersion": "0x3"
     }
   ]
 }

--- a/.github/workflows/_sdks_jest.yml
+++ b/.github/workflows/_sdks_jest.yml
@@ -35,11 +35,11 @@ jobs:
         with:
           scarb-lock: ./starknet-modular-account/Scarb.lock
 
-      - name: Build starknet contracts
-        run: scarb build
-
       - name: Configure environment for devnet and seed=0
         run: cp .env.template.json .env.devnet.json
+
+      - name: Build starknet contracts
+        run: scarb build
 
       - name: build the project
         run: npm run build

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,26 +10,31 @@ take the coming weeks and months.
 Ideas to enhance the account are legions. However, we plan to stay focus on a
 small set of features:
 
-1. Develop a Guarded Validator. This would require it to be a core validators.
+1. Add support for the version 3 of the transaction as described in
+   [SNIP-8](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md).
+2. Add an entrypoint to allow `execute_from_outside` with the signature from
+   the core validator and some limitation as described in
+   [SNIP-9](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-9.md).
+   This entrypoint would require to manage a user defined Nonce to prevent
+   replay-scenarios. It would also battle test the model. The benefit from that
+   entrypoint besides is that it allows a 3rd party to pay for your transaction.
+   A consolation prize for the paymaster to not be implemented yet. For some
+   implementation details:
+   - [Outside execution on Starknet Community](https://community.starknet.io/t/snip-outside-execution/101058)
+   - [Enabling meta-transactions on Starknet](https://docs.argent.xyz/aa-use-cases/outside-execution)
+   - [Using paymaster on AVNU Portal](https://doc.avnu.fi/avnu-paymaster/using-paymaster-on-avnu-portal)
+3. Develop a Guarded Validator. This would require it to be a core validators.
    It would provide more value for the modular account because the
    implementation requires some different signature depending on the calls so
    it would validate/invalidate the current set of interfaces.
-2. Add an entrypoint to allow `execute_from_outside` with the signature from
-   the core validator and some limitation. This entrypoint would require to
-   manage a user defined Nonce to prevent replay-scenarios. It would also
-   battle test the model. The benefit from that entrypoint besides is that it
-   allows a 3rd party to pay for your transaction. A consolation prize for the
-   paymaster to not be implemented yet.
-3. Move the Validator Module data from a prefix call to the account signature.
+4. Move the Validator Module data from a prefix call to the account signature.
    This might not be feasible but it makes sense because the validation is
    supposed to rely on the signature.
-4. Add support for Executor Modules. Some scenario like the ability to delay the
+5. Add support for Executor Modules. Some scenario like the ability to delay the
    execution of a transaction or the ability to track some data like an amount
    of ERC20 dedicated to a 3rd party requires those modules to work.
-5. Add support for the version 3 of the transaction as described in
-   [SNIP-8](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md).
-6. Ensure the compatibility between session key and
-   [SNIP-12](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md).
+6. Ensure the compatibility between session key and offchain signature à la
+   EIP-712 or [SNIP-12](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md).
 7. Check what can be done to support upgrades from OpenZeppelin, Argent and
    Braavo Accounts
 

--- a/docs/SDKS-INSTALL.md
+++ b/docs/SDKS-INSTALL.md
@@ -65,7 +65,7 @@ to your project, run the command below:
 ```shell
 npm install --save @0xknwn/starknet-modular-account
 
-npm install --save starknet@6.8.0
+npm install --save starknet@next
 ```
 
 ## Install the SessionKey Module SDK
@@ -78,5 +78,5 @@ npm install --save \
   @0xknwn/starknet-modular-account \
   @0xknwn/starknet-module-sessionkey
 
-npm install --save starknet@6.8.0
+npm install --save starknet@next
 ```

--- a/sdks/__tests__/helpers/src/class.test.ts
+++ b/sdks/__tests__/helpers/src/class.test.ts
@@ -1,16 +1,20 @@
 import { declareClass, classHash } from "./class";
 import { default_timeout } from "./parameters";
 import { testAccounts, config } from "./utils";
+import { data } from "./data.fixture";
 
-describe("class management", () => {
+describe.each(data)("class management", ({name, version, accountID}) => {
   const env = "devnet";
 
   it(
-    "deploys the Account class",
+    `[${name}] deploys the Account class`,
     async () => {
+      if (name === "WEI") {
+        return;
+      }
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      const output = await declareClass(account, "SimpleAccount");
+      const account = testAccounts(conf)[accountID];
+      const output = await declareClass(account, "SimpleAccount", {version: version.declare});
       expect(output.classHash).toEqual(classHash("SimpleAccount"));
     },
     default_timeout

--- a/sdks/__tests__/helpers/src/class.ts
+++ b/sdks/__tests__/helpers/src/class.ts
@@ -9,7 +9,7 @@ import { data as TokenAContract } from "./artifacts/TokenA-contract";
 import { data as TokenACompiled } from "./artifacts/TokenA-compiled";
 import { data as TokenBContract } from "./artifacts/TokenB-contract";
 import { data as TokenBCompiled } from "./artifacts/TokenB-compiled";
-
+import type { UniversalDetails } from "starknet";
 /**
  * Computes the hash of the requested class that is part of the
  * 0xknwn/starknet-modular-account project.
@@ -76,7 +76,8 @@ export const declareClass = async (
     | "SimpleAccount"
     | "SwapRouter"
     | "TokenA"
-    | "TokenB" = "Counter"
+    | "TokenB",
+    details?: UniversalDetails,
 ) => {
   const HelperClassHash = classHash(className);
 
@@ -138,7 +139,7 @@ export const declareClass = async (
   const declare = await account.declare({
     contract: compiledTestSierra,
     casm: compiledTestCasm,
-  });
+  }, details);
   return {
     ...(await account.waitForTransaction(declare.transaction_hash)),
     classHash: declare.class_hash,

--- a/sdks/__tests__/helpers/src/contract.test.ts
+++ b/sdks/__tests__/helpers/src/contract.test.ts
@@ -1,21 +1,32 @@
 import { classHash } from "./class";
 import { default_timeout } from "./parameters";
 import { hash } from "starknet";
+import { config } from "./utils";
+import { data } from "./data.fixture";
 
-describe("contract management (helper)", () => {
+
+const expected = {
+  SimpleAccountClassHash: "0x1a3f5a334da41fc1eb5940c691f13df75a215967b0ce9b5a78c5cff4e847293",
+  SimpleAccountAddress:  {
+    "WEI": "0x4a3c9f794dfa1b6a63e344720e4806a04160237b8aa9771e6f76ae9326eca5f",
+    "FRI": "0x660009647f265d0038500552d4563331c2aa25e96f9a69506032ba30c085e4d",
+  } as { [id: string]: string; },}
+
+describe.each(data)("contract management (helper)", ({name, version, accountID}) => {
   let env: string = "devnet";
 
   it(
-    "computes an account adddress",
+    `[${name}] computes an account adddress`,
     async () => {
-      const publicKey =
-        "0x39d9e6ce352ad4530a0ef5d5a18fd3303c3606a7fa6ac5b620020ad681cc33b";
-        const class_hash = classHash("SimpleAccount");
+      const conf = config(env);
+            
+      const publicKey = conf.accounts[accountID].publicKey;
+      const class_hash = classHash("SimpleAccount");
       expect(class_hash).toBe(
-        "0x1a3f5a334da41fc1eb5940c691f13df75a215967b0ce9b5a78c5cff4e847293"
+        expected.SimpleAccountClassHash
       );
       const constructorCallData = [
-        "0x39d9e6ce352ad4530a0ef5d5a18fd3303c3606a7fa6ac5b620020ad681cc33b",
+        publicKey,
         "0x10",
       ];
       // compute the account address
@@ -26,7 +37,7 @@ describe("contract management (helper)", () => {
         0
       );
       expect(account_address).toBe(
-        "0x4a3c9f794dfa1b6a63e344720e4806a04160237b8aa9771e6f76ae9326eca5f"
+        expected.SimpleAccountAddress[name]
       );
     },
     default_timeout

--- a/sdks/__tests__/helpers/src/contract.ts
+++ b/sdks/__tests__/helpers/src/contract.ts
@@ -1,8 +1,8 @@
 import { classHash } from "./class";
 import { Contract, Account, hash, ec } from "starknet";
-import { udcAddress, ETH } from "./natives";
-import { initial_EthTransfer } from "./parameters";
-import { type Abi } from "starknet";
+import { udcAddress, ETH, STRK } from "./natives";
+import { initial_EthTransfer, initial_StrkTransfer } from "./parameters";
+import type { Abi, UniversalDetails } from "starknet";
 
 /**
  * Calculates the contract address for a given contract name, deployer address,
@@ -63,7 +63,8 @@ export const deployContract = async (
   contractName: "Counter" | "SwapRouter" | "TokenA" | "TokenB" = "Counter",
   ABI: Abi,
   deployerAccount: Account,
-  constructorCalldata: any[]
+  constructorCalldata: any[],
+  details?: UniversalDetails,
 ): Promise<Contract> => {
   const classH = classHash(contractName);
   // check if the contract is already deployed and if it has been, return the
@@ -84,7 +85,8 @@ export const deployContract = async (
     classHash: classH,
     constructorCalldata: constructorCalldata,
     salt: "0x0",
-  });
+  }, 
+  details);
   await deployerAccount.waitForTransaction(deployResponse.transaction_hash);
   return new Contract(ABI, deployResponse.contract_address, deployerAccount);
 };
@@ -103,7 +105,8 @@ export const deployAccount = async (
   deployerAccount: Account,
   accountName: "SimpleAccount",
   publicKey: string,
-  constructorCalldata: any[]
+  constructorCalldata: any[],
+  details?: UniversalDetails,
 ) => {
   if (!accountName) {
     throw new Error(`the account name is required`);
@@ -124,9 +127,19 @@ export const deployAccount = async (
   } catch (e) {}
 
   // transfer some eth to the account
-  const { transaction_hash } = await ETH(deployerAccount).transfer(
+  let version = deployerAccount.transactionVersion
+  if (details && details.version) {
+    if (details.version === 3) {
+      version = "0x3";
+    } else if (details.version === 2) {
+      version = "0x2";
+    }
+  } 
+  const TOKEN = (version === "0x2" ? ETH : STRK)
+  const initial_Transfer = (version === "0x2" ? initial_EthTransfer : initial_StrkTransfer)
+  const { transaction_hash } = await TOKEN(deployerAccount).transfer(
     computedAccountAddress,
-    initial_EthTransfer
+    initial_Transfer
   );
   let receipt = await deployerAccount.waitForTransaction(transaction_hash);
   if (!receipt.isSuccess()) {
@@ -141,7 +154,7 @@ export const deployAccount = async (
       classHash: computedClassHash,
       constructorCalldata,
       addressSalt: publicKey,
-    });
+    }, details);
   receipt = await deployerAccount.waitForTransaction(tx);
   if (!receipt.isSuccess()) {
     throw new Error(`Failed to deploy account: ${receipt.status}`);

--- a/sdks/__tests__/helpers/src/counter.test.ts
+++ b/sdks/__tests__/helpers/src/counter.test.ts
@@ -2,12 +2,20 @@ import { declareClass, classHash } from "./class";
 import { testAccounts, config } from "./utils";
 import { deployCounter, counterAddress, CounterABI } from "./counter";
 import { default_timeout } from "./parameters";
-import { Contract, type Call, RpcProvider, Account } from "starknet";
+import { Contract, type Call, RpcProvider, Account, UniversalDetails } from "starknet";
 
-describe("counter contract (helper)", () => {
+import { data } from "./data.fixture";
+  
+describe.each(data)("counter contract (helper)", ({ name, version, accountID }) => {
   let env: string;
   let counter: Contract;
   let altURL: string;
+  const redeployCounter = async (account: Account, details?: UniversalDetails) => {
+    if (!counter) {
+      counter = await deployCounter(account, account.address, details);
+    }
+  }
+  
   beforeAll(() => {
     env = "devnet";
     const conf = config(env);
@@ -18,22 +26,22 @@ describe("counter contract (helper)", () => {
   });
 
   it(
-    "declare the Counter class",
+    `[${name}] declare the Counter class`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      const c = await declareClass(account, "Counter");
+      const account = testAccounts(conf)[accountID];
+      const c = await declareClass(account, "Counter", {version: version.declare});
       expect(c.classHash).toEqual(classHash("Counter"));
     },
     default_timeout
   );
 
   it(
-    "deploys the Counter contract",
+    `[${name}] deploys the Counter contract`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      const c = await deployCounter(account, account.address);
+      const account = testAccounts(conf)[accountID];
+      const c = await deployCounter(account, account.address, {version: version.invoke});
       expect(c.address).toEqual(
         await counterAddress(account.address, account.address)
       );
@@ -43,15 +51,13 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "increments the counter",
+    `[${name}] increments the counter`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const transferCall: Call = counter.populate("increment", {});
-      const { transaction_hash } = await account.execute(transferCall);
+      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
       const receipt = await account.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
     },
@@ -59,13 +65,11 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "reads the counter",
+    `[${name}] reads the counter`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const c = await counter.get();
       expect(c).toBeGreaterThan(0n);
     },
@@ -73,17 +77,15 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "increments the counter by 5 and 6",
+    `[${name}] increments the counter by 5 and 6`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const transferCall: Call = counter.populate("increment_by_array", {
         args: [5, 6],
       });
-      const { transaction_hash } = await account.execute(transferCall);
+      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
       const receipt = await account.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
     },
@@ -91,13 +93,11 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "reads the counter again",
+    `[${name}] reads the counter again`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const c = await counter.get();
       expect(c).toBeGreaterThan(11n);
     },
@@ -105,15 +105,13 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "resets the counter",
+    `[${name}] resets the counter`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const transferCall: Call = counter.populate("reset", {});
-      const { transaction_hash } = await account.execute(transferCall);
+      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
       const receipt = await account.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
     },
@@ -121,13 +119,11 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "reads the counter again",
+    `[${name}] reads the counter again`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const c = await counter.get();
       expect(c).toBe(0n);
     },
@@ -135,15 +131,13 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "increments the counter from another account",
+    `[${name}] increments the counter from another account`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[1];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[2];
+      redeployCounter(account, {version: version.invoke});
       const transferCall: Call = counter.populate("increment", {});
-      const { transaction_hash } = await account.execute(transferCall);
+      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
       const receipt = await account.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
     },
@@ -151,13 +145,11 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "reads the counter",
+    `[${name}] reads the counter`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const c = await counter.get();
       expect(c).toBeGreaterThan(0n);
     },
@@ -165,16 +157,14 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "resets the counter and fails",
+    `[${name}] resets the counter and fails`,
     async () => {
       const conf = config(env);
-      let account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      let account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const transferCall: Call = counter.populate("reset", {});
       try {
-        account = testAccounts(conf)[1];
+        account = testAccounts(conf)[2];
         const { transaction_hash } = await account.execute(transferCall);
         await account.waitForTransaction(transaction_hash);
         expect(true).toBe(false);
@@ -186,13 +176,11 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "reads the counter again",
+    `[${name}] reads the counter again`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const c = await counter.get();
       expect(c).toBeGreaterThan(0n);
     },
@@ -200,21 +188,19 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "increments the counter with an alt provider URL",
+    `[${name}] increments the counter with an alt provider URL`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const provider = new RpcProvider({ nodeUrl: altURL });
       const a = new Account(
         provider,
-        conf.accounts[0].address,
-        conf.accounts[0].privateKey
+        conf.accounts[accountID].address,
+        conf.accounts[accountID].privateKey
       );
       const transferCall: Call = counter.populate("increment", {});
-      const { transaction_hash } = await account.execute(transferCall);
+      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
       const receipt = await a.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
     },
@@ -222,13 +208,11 @@ describe("counter contract (helper)", () => {
   );
 
   it(
-    "reads the counter from an alt. provider URL",
+    `[${name}] reads the counter from an alt. provider URL`,
     async () => {
       const conf = config(env);
-      const account = testAccounts(conf)[0];
-      if (!counter) {
-        counter = await deployCounter(account, account.address);
-      }
+      const account = testAccounts(conf)[accountID];
+      redeployCounter(account, {version: version.invoke});
       const provider = new RpcProvider({ nodeUrl: altURL });
       const altCounter = new Contract(
         CounterABI,

--- a/sdks/__tests__/helpers/src/counter.ts
+++ b/sdks/__tests__/helpers/src/counter.ts
@@ -1,4 +1,4 @@
-import { Contract, Call, Account, CallData } from "starknet";
+import { Contract, Call, Account, CallData, UniversalDetails } from "starknet";
 import { ABI as CounterABI } from "./abi/Counter";
 import { contractAddress, deployContract } from "./contract";
 
@@ -27,13 +27,14 @@ export const counterAddress = async (
  */
 export const deployCounter = async (
   deployerAccount: Account,
-  ownerAddress: string
+  ownerAddress: string,
+  details?: UniversalDetails,
 ): Promise<Contract> => {
   const myCallData = new CallData(CounterABI);
   const _calldata = myCallData.compile("constructor", {
     owner: ownerAddress,
   });
-  return deployContract("Counter", CounterABI, deployerAccount, _calldata);
+  return deployContract("Counter", CounterABI, deployerAccount, _calldata, details);
 };
 
 export { CounterABI };

--- a/sdks/__tests__/helpers/src/data.fixture.ts
+++ b/sdks/__tests__/helpers/src/data.fixture.ts
@@ -1,0 +1,22 @@
+const { V1, V2, V3 } = { V1: 1, V2: 2, V3: 3 };
+
+export const data = [
+  {
+    name: "WEI",
+    version: {
+      invoke: V1,
+      declare: V2,
+      deploy_account: V1,
+    },
+    accountID: 0,
+  },
+  {
+    name: "FRI",
+    version: {
+      invoke: V3,
+      declare: V3,
+      deploy_account: V3,
+    },
+    accountID: 1,
+  },
+];

--- a/sdks/__tests__/helpers/src/natives.test.ts
+++ b/sdks/__tests__/helpers/src/natives.test.ts
@@ -1,27 +1,30 @@
 import { config, testAccounts } from "./utils";
 import { initial_EthTransfer, default_timeout } from "./parameters";
-import { ETH } from "./natives";
-import { RpcProvider, uint256, cairo } from "starknet";
+import { ETH, STRK } from "./natives";
+import { RpcProvider, uint256 } from "starknet";
 
-describe("native tokens management", () => {
+import { data } from "./data.fixture";
+
+
+describe.each(data)("native tokens management", ({ name, accountID }) => {
   let env = "devnet";
 
-  it("checks an $ETH balance", async () => {
+  it(`[${name}] checks an $ETH balance`, async () => {
     const conf = config(env);
     const provider = new RpcProvider({ nodeUrl: conf.providerURL });
     const amount = await (
       await ETH(provider)
-    ).balance_of(testAccounts(conf)[0].address);
+    ).balance_of(testAccounts(conf)[accountID].address);
     expect(amount).toBeGreaterThanOrEqual(
       3n * uint256.uint256ToBN(initial_EthTransfer)
     );
   });
 
-  it("checks an $STRK balance", async () => {
+  it(`[${name}] checks an $STRK balance`, async () => {
     const conf = config(env);
     const provider = new RpcProvider({ nodeUrl: conf.providerURL });
     const amount = await ETH(provider).balance_of(
-      testAccounts(conf)[0].address
+      testAccounts(conf)[accountID].address
     );
     switch (env) {
       case "sepolia":
@@ -36,12 +39,13 @@ describe("native tokens management", () => {
   });
 
   it(
-    "transfers $ETH",
+    `[${name}] transfers ${name === "WEI" ? "$ETH" : "$STRK"}`,
     async () => {
       const conf = config(env);
       const accounts = testAccounts(conf);
-      const eth = ETH(accounts[0]);
-      const destAddress = accounts[1].address;
+      const TOKEN = (name === "WEI" ? ETH : STRK)
+      const eth = TOKEN(accounts[accountID]);
+      const destAddress = accounts[2].address;
       const initialAmount = (await eth.balance_of(destAddress)) as bigint;
 
       const { transaction_hash } = await eth.transfer(

--- a/sdks/__tests__/helpers/src/parameters.ts
+++ b/sdks/__tests__/helpers/src/parameters.ts
@@ -2,3 +2,4 @@ import { cairo } from "starknet";
 
 export const default_timeout = 120000;
 export const initial_EthTransfer = cairo.uint256(3n * 10n ** 15n);
+export const initial_StrkTransfer = cairo.uint256(10000n * 10n ** 15n);

--- a/sdks/__tests__/helpers/src/simple_account.test.ts
+++ b/sdks/__tests__/helpers/src/simple_account.test.ts
@@ -3,8 +3,9 @@ import { deploySimpleAccount, simpleAccountAddress } from "./simple_account";
 import { config, testAccounts } from "./utils";
 import { Account, RpcProvider } from "starknet";
 import { default_timeout } from "./parameters";
+import { data } from "./data.fixture";
 
-describe("simple account management", () => {
+describe.each(data)("simple account management", ({ name, version, accountID }) => {
   let env: string;
   let simpleAccount: Account;
   beforeAll(() => {
@@ -18,25 +19,25 @@ describe("simple account management", () => {
   });
 
   it(
-    "deploys the Account class",
+    `[${name}] deploys the Account class`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
-      const c = await declareClass(a, "SimpleAccount");
+      const a = testAccounts(conf)[accountID];
+      const c = await declareClass(a, "SimpleAccount", { version: version.declare });
       expect(c.classHash).toEqual(classHash("SimpleAccount"));
     },
     default_timeout
   );
 
   it(
-    "deploys the account contract",
+    `[${name}] deploys the account contract`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
-      const publicKey = conf.accounts[0].publicKey;
-      const c = await deploySimpleAccount(a, publicKey, "0x10");
+      const a = testAccounts(conf)[accountID];
+      const publicKey = conf.accounts[accountID].publicKey;
+      const c = await deploySimpleAccount(a, publicKey, "0x10", { version: version.invoke });
       expect(c).toEqual(
-        simpleAccountAddress(conf.accounts[0].publicKey, "0x10")
+        simpleAccountAddress(conf.accounts[accountID].publicKey, "0x10")
       );
     },
     default_timeout

--- a/sdks/__tests__/helpers/src/simple_account.ts
+++ b/sdks/__tests__/helpers/src/simple_account.ts
@@ -1,4 +1,4 @@
-import { Account, CallData } from "starknet";
+import { Account, CallData, type UniversalDetails } from "starknet";
 import { ABI as SimpleAccountABI } from "./abi/SimpleAccount";
 import { accountAddress, deployAccount } from "./contract";
 export { SimpleAccountABI };
@@ -32,7 +32,8 @@ export const simpleAccountAddress = (
 export const deploySimpleAccount = async (
   deployerAccount: Account,
   publicKey: string,
-  more: string
+  more: string,
+  details?: UniversalDetails
 ) => {
   const callData = new CallData(SimpleAccountABI).compile("constructor", {
     public_key: publicKey,
@@ -42,6 +43,7 @@ export const deploySimpleAccount = async (
     deployerAccount,
     "SimpleAccount",
     publicKey,
-    callData
+    callData,
+    details
   );
 };

--- a/sdks/__tests__/helpers/src/swap_router.test.ts
+++ b/sdks/__tests__/helpers/src/swap_router.test.ts
@@ -13,8 +13,9 @@ import { swapRouterAddress, deploySwapRouter } from "./swap_router";
 import { default_timeout } from "./parameters";
 import { ec, hash, cairo, Contract } from "starknet";
 import { SwapRouter } from "./swap_router";
+import { data } from "./data.fixture";
 
-describe("swap router", () => {
+describe.each(data)("swap router", ({ name, version, accountID }) => {
   let env: string;
   let altProviderURL: string;
   let swapRouterContract: SwapRouter;
@@ -29,22 +30,22 @@ describe("swap router", () => {
   });
 
   it(
-    "declares the SwapRouter class",
+    `[${name}] declares the SwapRouter class`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
-      const c = await declareClass(a, "SwapRouter");
+      const a = testAccounts(conf)[accountID];
+      const c = await declareClass(a, "SwapRouter", { version: version.declare });
       expect(c.classHash).toEqual(classHash("SwapRouter"));
     },
     default_timeout
   );
 
   it(
-    "deploys the SwapRouter contract",
+    `[${name}] deploys the SwapRouter contract`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
-      const c = await deploySwapRouter(a, a.address);
+      const a = testAccounts(conf)[accountID];
+      const c = await deploySwapRouter(a, a.address, { version: version.invoke });
       const routerAddress = await swapRouterAddress(a.address, a.address);
       swapRouterContract = new SwapRouter(routerAddress, a);
       expect(c.address).toEqual(routerAddress);
@@ -53,22 +54,22 @@ describe("swap router", () => {
   );
 
   it(
-    "declares the TokenA class",
+    `[${name}] declares the TokenA class`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
-      const c = await declareClass(a, "TokenA");
+      const a = testAccounts(conf)[accountID];
+      const c = await declareClass(a, "TokenA", { version: version.declare });
       expect(c.classHash).toEqual(classHash("TokenA"));
     },
     default_timeout
   );
 
   it(
-    "deploys the TokenA contract",
+    `[${name}] deploys the TokenA contract`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
-      const c = await deployTokenA(a, swapRouterContract.address, a.address);
+      const a = testAccounts(conf)[accountID];
+      const c = await deployTokenA(a, swapRouterContract.address, a.address, { version: version.invoke });
       tokenA = new Contract(
         TokenAABI,
         await tokenAAddress(a.address, swapRouterContract.address, a.address),
@@ -82,22 +83,22 @@ describe("swap router", () => {
   );
 
   it(
-    "declares the TokenB class",
+    `[${name}] declares the TokenB class`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
-      const c = await declareClass(a, "TokenB");
+      const a = testAccounts(conf)[accountID];
+      const c = await declareClass(a, "TokenB", { version: version.declare });
       expect(c.classHash).toEqual(classHash("TokenB"));
     },
     default_timeout
   );
 
   it(
-    "deploys the TokenB contract",
+    `[${name}] deploys the TokenB contract`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
-      const c = await deployTokenB(a, swapRouterContract.address, a.address);
+      const a = testAccounts(conf)[accountID];
+      const c = await deployTokenB(a, swapRouterContract.address, a.address, { version: version.invoke });
       tokenB = new Contract(
         TokenBABI,
         await tokenBAddress(a.address, swapRouterContract.address, a.address),
@@ -110,9 +111,10 @@ describe("swap router", () => {
     default_timeout
   );
 
-  it("compute and check TokenA address", async () => {
+  it(
+    `[${name}] compute and check TokenA address`, async () => {
     const conf = config(env);
-    const a = testAccounts(conf)[0];
+    const a = testAccounts(conf)[accountID];
     const creatorAddress = a.address;
     const recipientAddress = swapRouterContract.address;
     const ownerAddress = a.address;
@@ -134,7 +136,7 @@ describe("swap router", () => {
   });
 
   it(
-    "sets the tokens in the SwapRouter",
+    `[${name}] sets the tokens in the SwapRouter`,
     async () => {
       const is_paused = await swapRouterContract.is_paused();
       if (!is_paused) {
@@ -151,10 +153,10 @@ describe("swap router", () => {
   );
 
   it(
-    "checks tokenA and tokenB initial account balance",
+    `[${name}] checks tokenA and tokenB initial account balance`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
+      const a = testAccounts(conf)[accountID];
       let balance = await tokenA.balance_of(a.address);
       expect(balance).toBeGreaterThanOrEqual(0n);
       tokenAInitialBalance = balance;
@@ -166,7 +168,7 @@ describe("swap router", () => {
   );
 
   it(
-    "requests tokenA to the faucet",
+    `[${name}] requests tokenA to the faucet`,
     async () => {
       const receipt = await swapRouterContract.faucet(
         cairo.uint256(2n * 10n ** 18n)
@@ -177,13 +179,13 @@ describe("swap router", () => {
   );
 
   it(
-    "checks the account has been funded with tokenA",
+    `[${name}] checks the account has been funded with tokenA`,
     async () => {
       if (tokenAInitialBalance === undefined) {
         throw new Error("tokenAInitialBalance is undefined");
       }
       const conf = config(env);
-      const a = testAccounts(conf)[0];
+      const a = testAccounts(conf)[accountID];
       const balance = await tokenA.balance_of(a.address);
       expect(balance - tokenAInitialBalance).toBeGreaterThanOrEqual(
         2000000000000000000n
@@ -193,10 +195,10 @@ describe("swap router", () => {
   );
 
   it(
-    "swaps tokenA for tokenB",
+    `[${name}] swaps tokenA for tokenB`,
     async () => {
       const conf = config(env);
-      const a = testAccounts(conf)[0];
+      const a = testAccounts(conf)[accountID];
       // @todo: fix this test and/or the swap function
       const receipt = await swapRouterContract.swap(
         tokenA.address,
@@ -208,13 +210,13 @@ describe("swap router", () => {
   );
 
   it(
-    "checks the account has been funded with tokenB",
+    `[${name}] checks the account has been funded with tokenB`,
     async () => {
       if (tokenBInitialBalance === undefined) {
         throw new Error("tokenAInitialBalance is undefined");
       }
       const conf = config(env);
-      const a = testAccounts(conf)[0];
+      const a = testAccounts(conf)[accountID];
       const balance = await tokenB.balance_of(a.address);
       expect(balance - tokenBInitialBalance).toBeGreaterThanOrEqual(10n ** 15n);
     },

--- a/sdks/__tests__/helpers/src/swap_router.ts
+++ b/sdks/__tests__/helpers/src/swap_router.ts
@@ -1,9 +1,9 @@
 import { Contract, Call, Account, CallData } from "starknet";
 import { ABI as SwapRouterABI } from "./abi/SwapRouter";
 import { contractAddress, deployContract } from "./contract";
-import { type Uint256 } from "starknet";
+import type { Uint256, UniversalDetails } from "starknet";
 import { ABI as TokenAABI } from "./abi/TokenA";
-import { ABI as TokenBABI } from "./abi/TokenB";
+
 /**
  * Retrieves the swap router address from its deployer and owner.
  * @param deployerAddress - The address of the deployer.
@@ -29,7 +29,8 @@ export const swapRouterAddress = async (
  */
 export const deploySwapRouter = async (
   deployerAccount: Account,
-  ownerAddress: string
+  ownerAddress: string,
+  details?: UniversalDetails
 ): Promise<Contract> => {
   const myCallData = new CallData(SwapRouterABI);
   const _calldata = myCallData.compile("constructor", {
@@ -39,7 +40,8 @@ export const deploySwapRouter = async (
     "SwapRouter",
     SwapRouterABI,
     deployerAccount,
-    _calldata
+    _calldata,
+    details
   );
 };
 

--- a/sdks/__tests__/helpers/src/tokens.ts
+++ b/sdks/__tests__/helpers/src/tokens.ts
@@ -1,4 +1,4 @@
-import { Contract, RpcProvider, Account, CallData, uint256 } from "starknet";
+import { Contract, type UniversalDetails, Account, CallData } from "starknet";
 import { deployContract } from "./contract";
 import { ABI as TokenAABI } from "./abi/TokenA";
 import { ABI as TokenBABI } from "./abi/TokenB";
@@ -29,14 +29,15 @@ export const tokenAAddress = async (
 export const deployTokenA = async (
   deployerAccount: Account,
   recipientAddress: string,
-  ownerAddress: string
+  ownerAddress: string,
+  details?: UniversalDetails
 ): Promise<Contract> => {
   const myCallData = new CallData(TokenAABI);
   const _calldata = myCallData.compile("constructor", {
     recipient: recipientAddress,
     owner: ownerAddress,
   });
-  return deployContract("TokenA", TokenAABI, deployerAccount, _calldata);
+  return deployContract("TokenA", TokenAABI, deployerAccount, _calldata, details);
 };
 
 /**
@@ -63,12 +64,13 @@ export const tokenBAddress = async (
 export const deployTokenB = async (
   deployerAccount: Account,
   recipientAddress: string,
-  ownerAddress: string
+  ownerAddress: string,
+  details?: UniversalDetails
 ): Promise<Contract> => {
   const myCallData = new CallData(TokenBABI);
   const _calldata = myCallData.compile("constructor", {
     recipient: recipientAddress,
     owner: ownerAddress,
   });
-  return deployContract("TokenB", TokenBABI, deployerAccount, _calldata);
+  return deployContract("TokenB", TokenBABI, deployerAccount, _calldata, details);
 };

--- a/sdks/__tests__/helpers/src/utils.test.ts
+++ b/sdks/__tests__/helpers/src/utils.test.ts
@@ -16,7 +16,8 @@ describe("utilities (helpers)", () => {
         expect(c.accounts[0].address).not.toBe(undefined);
         break;
       default:
-        expect(c.providerURL).toBe("http://127.0.0.1:5050/rpc");
+        expect(c.providerURL).toContain("http://127.0.0.1");
+        expect(c.providerURL).toContain("/rpc");
         expect(c.accounts[0]).not.toBe(undefined);
         expect(c.accounts[0].address).not.toBe(undefined);
         break;

--- a/sdks/__tests__/helpers/src/utils.ts
+++ b/sdks/__tests__/helpers/src/utils.ts
@@ -13,6 +13,8 @@ export type AccountConfig = {
   privateKey: string;
   // The public key.
   publicKey: string;
+  // The public key.
+  defaultTransactionVersion: "0x2" | "0x3";
 };
 
 /**
@@ -58,7 +60,9 @@ export const testAccounts = (config: Config): Account[] => {
     const account = new Account(
       provider,
       configAccount.address,
-      configAccount.privateKey
+      configAccount.privateKey,
+      '1',
+      configAccount.defaultTransactionVersion,
     );
     accounts.push(account);
   }


### PR DESCRIPTION
## Summary

add tests to @0xknwn/starknet-test-helpers to show both txn v1/v2 and v3

## Impacts on the signers

It should not impact the signer as the default should remain the same

## Changes

- add the `details?: UniversalDetails` parameter when required
- check the transactionVersion that is set at the Account level
- modify the `deployAccount` to transfer STRK instead of ETH when the transaction version is 0x3

## Checklist:

- [x] Link the associated issue (see #184)
- [x] Perform a self-review of the code
- [x] Rebase to the head of the `develop` branch from 0xknow/starknet-modular-account
- [x] Document the changes in code
- [x] Make sure the code is properly formatted by running `scarb fmt`
- [ ] Add unit tests with starknet foundry
- [x] Add integration tests with starknet.js and jest
- [x] Pass all the tests
