### PR TITLE
improve browser support and use enum for classNames

### DIFF
--- a/experiments/documentation-examples/package.json
+++ b/experiments/documentation-examples/package.json
@@ -16,6 +16,6 @@
     "@0xknwn/starknet-test-helpers": "^0.2.1"
   },
   "devDependencies": {
-    "starknet": "^6.21.0"
+    "starknet": "^6.21.1"
   }
 }

--- a/experiments/starknet-bootstrap-account/package.json
+++ b/experiments/starknet-bootstrap-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-bootstrap-account",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,7 +13,8 @@
   "author": "0xknwn",
   "license": "MIT",
   "dependencies": {
-    "@0xknwn/starknet-test-helpers": "^0.2.1"
+    "@0xknwn/starknet-test-helpers": "^0.2.2",
+    "@0xknwn/starknet-modular-account": "^0.2.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",

--- a/experiments/starknet-bootstrap-account/package.json
+++ b/experiments/starknet-bootstrap-account/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/experiments/starknet-bootstrap-account/src/bootstrap_account.test.ts
+++ b/experiments/starknet-bootstrap-account/src/bootstrap_account.test.ts
@@ -6,9 +6,19 @@ import {
   config,
   initial_EthTransfer,
   ETH,
+  classNames as helperaccountClassNames,
 } from "@0xknwn/starknet-test-helpers";
+import {
+  declareClass as declareAccountClass,
+  classNames as accountClassNames,
+  classHash as accountClassHash,
+} from "@0xknwn/starknet-modular-account";
 import { bootstrapAccountAddress } from "./bootstrap_account";
-import { classHash, declareClass as declareBootstrapClass } from "./class";
+import {
+  classHash,
+  declareClass as declareBootstrapClass,
+  classNames,
+} from "./class";
 import { deployAccount } from "./contract";
 import { Account, RpcProvider, CallData } from "starknet";
 import { ABI as AccountABI } from "./abi/BootstrapAccount";
@@ -22,12 +32,14 @@ describe("bootstrapping an account", () => {
   });
 
   it(
-    "declares the SimpleAccount class",
+    "declares the SimpleValidator class",
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await declareHelperClass(a, "SimpleAccount");
-      expect(c.classHash).toEqual(helperClassHash("SimpleAccount"));
+      const c = await declareAccountClass(a, accountClassNames.SimpleValidator);
+      expect(c.classHash).toEqual(
+        accountClassHash(accountClassNames.SimpleValidator)
+      );
     },
     default_timeout
   );
@@ -37,8 +49,8 @@ describe("bootstrapping an account", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await declareBootstrapClass(a, "BootstrapAccount");
-      expect(c.classHash).toEqual(classHash("BootstrapAccount"));
+      const c = await declareBootstrapClass(a, classNames.BootstrapAccount);
+      expect(c.classHash).toEqual(classHash(classNames.BootstrapAccount));
     },
     default_timeout
   );
@@ -53,7 +65,7 @@ describe("bootstrapping an account", () => {
       const privateKey = conf.accounts[0].privateKey;
       const address = bootstrapAccountAddress(
         publicKey,
-        helperClassHash("SimpleAccount")
+        accountClassHash(accountClassNames.SimpleValidator)
       );
       const { transaction_hash } = await ETH(sender).transfer(
         address,
@@ -74,7 +86,7 @@ describe("bootstrapping an account", () => {
       const publicKey = conf.accounts[0].publicKey;
       const calldata = new CallData(AccountABI).compile("constructor", {
         public_key: publicKey,
-        target_class: helperClassHash("SimpleAccount"),
+        target_class: accountClassHash(accountClassNames.SimpleValidator),
       });
       const address = await deployAccount(
         account,
@@ -85,7 +97,7 @@ describe("bootstrapping an account", () => {
       expect(address).toEqual(
         bootstrapAccountAddress(
           conf.accounts[0].publicKey,
-          helperClassHash("SimpleAccount")
+          accountClassHash(accountClassNames.SimpleValidator)
         )
       );
     },
@@ -93,17 +105,19 @@ describe("bootstrapping an account", () => {
   );
 
   it(
-    "checks the account class is now SimpleAccount",
+    "checks the account class is now SimpleValidator",
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
       const accountClass = await a.getClassHashAt(
         bootstrapAccountAddress(
           conf.accounts[0].publicKey,
-          helperClassHash("SimpleAccount")
+          accountClassHash(accountClassNames.SimpleValidator)
         )
       );
-      expect(accountClass).toEqual(helperClassHash("SimpleAccount"));
+      expect(accountClass).toEqual(
+        accountClassHash(accountClassNames.SimpleValidator)
+      );
     },
     default_timeout
   );

--- a/experiments/starknet-bootstrap-account/src/class.ts
+++ b/experiments/starknet-bootstrap-account/src/class.ts
@@ -17,6 +17,10 @@ export const classHash = (className: "BootstrapAccount") => {
   return hash.computeContractClassHash(contract);
 };
 
+export enum classNames {
+  BootstrapAccount = "BootstrapAccount",
+}
+
 /**
  * If not already declared, declare the requested class from the
  * 0xknwn/bootstrap-account project to the Starknet network used by the
@@ -33,7 +37,7 @@ export const classHash = (className: "BootstrapAccount") => {
  */
 export const declareClass = async (
   account: Account,
-  className: "BootstrapAccount" = "BootstrapAccount"
+  className: classNames.BootstrapAccount = classNames.BootstrapAccount
 ) => {
   const AccountClassHash = classHash(className);
 

--- a/experiments/starknet-bootstrap-account/src/class.ts
+++ b/experiments/starknet-bootstrap-account/src/class.ts
@@ -1,4 +1,5 @@
 import { hash, json, CompiledContract, Account } from "starknet";
+import { Buffer } from "buffer";
 import { data as BootstrapAccountContract } from "./artifacts/BootstrapAccount-contract";
 import { data as BootstrapAccountCompiled } from "./artifacts/BootstrapAccount-compiled";
 /**

--- a/experiments/starknet-bootstrap-account/tsconfig.json
+++ b/experiments/starknet-bootstrap-account/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "dist"
   },
   "references": [
-    { "path": "../../sdks/__tests__/helpers" }
+    { "path": "../../sdks/__tests__/helpers" },
+    { "path": "../../sdks/account" }
   ],
   "typedocOptions": {
     "entryPoints": ["src/index.ts"],

--- a/experiments/starknet-failed-account/package.json
+++ b/experiments/starknet-failed-account/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/experiments/starknet-failed-account/package.json
+++ b/experiments/starknet-failed-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-failed-account",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,7 +13,8 @@
   "author": "0xknwn",
   "license": "MIT",
   "dependencies": {
-    "@0xknwn/starknet-test-helpers": "^0.2.1"
+    "@0xknwn/starknet-test-helpers": "^0.2.2",
+    "@0xknwn/starknet-modular-account": "^0.2.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",

--- a/experiments/starknet-failed-account/src/class.ts
+++ b/experiments/starknet-failed-account/src/class.ts
@@ -1,4 +1,5 @@
 import { hash, json, CompiledContract, Account } from "starknet";
+import { Buffer } from "buffer";
 import { data as FailedAccountContract } from "./artifacts/FailedAccount-contract";
 import { data as FailedAccountCompiled } from "./artifacts/FailedAccount-compiled";
 /**

--- a/experiments/starknet-failed-account/src/class.ts
+++ b/experiments/starknet-failed-account/src/class.ts
@@ -11,11 +11,15 @@ import { data as FailedAccountCompiled } from "./artifacts/FailedAccount-compile
  * `scarb build` command at the root of the project.
  *
  */
-export const classHash = (className: "FailedAccount") => {
+export const classHash = (className: classNames.FailedAccount) => {
   const f = Buffer.from(FailedAccountContract, "base64");
   const contract: CompiledContract = json.parse(f.toString("ascii"));
   return hash.computeContractClassHash(contract);
 };
+
+export enum classNames {
+  FailedAccount = "FailedAccount",
+}
 
 /**
  * If not already declared, declare the requested class from the
@@ -33,7 +37,7 @@ export const classHash = (className: "FailedAccount") => {
  */
 export const declareClass = async (
   account: Account,
-  className: "FailedAccount" = "FailedAccount"
+  className: classNames.FailedAccount = classNames.FailedAccount
 ) => {
   const AccountClassHash = classHash(className);
 

--- a/experiments/starknet-failed-account/src/contract.ts
+++ b/experiments/starknet-failed-account/src/contract.ts
@@ -1,5 +1,5 @@
 import { Account, Contract, hash, num } from "starknet";
-import { classHash } from "./class";
+import { classHash, classNames } from "./class";
 import { ABI as ERC20ABI } from "./abi/ERC20";
 import { ethAddress } from "./natives";
 /**
@@ -12,7 +12,7 @@ import { ethAddress } from "./natives";
  * `scarb build` command at the root of the project.
  */
 export const accountAddress = (
-  accountName: "FailedAccount",
+  accountName: classNames.FailedAccount,
   publicKey: string,
   constructorCallData: string[]
 ): string => {
@@ -37,7 +37,7 @@ export const accountAddress = (
  */
 export const deployAccount = async (
   deployerAccount: Account,
-  accountName: "FailedAccount",
+  accountName: classNames.FailedAccount,
   publicKey: string,
   constructorCalldata: any[]
 ) => {

--- a/experiments/starknet-failed-account/src/failed_account.test.ts
+++ b/experiments/starknet-failed-account/src/failed_account.test.ts
@@ -9,10 +9,12 @@ import {
   config,
   ETH,
   initial_EthTransfer,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   classHash as failedClassHash,
   declareClass as declareFailedClass,
+  classNames,
 } from "./class";
 import { deployAccount } from "./contract";
 import { failedAccountAddress, deployFailedAccount } from "./failed_account";
@@ -32,8 +34,8 @@ describe("sessionkey management", () => {
     async () => {
       const conf = config(env);
       const account = testAccounts(conf)[0];
-      const c = await declareHelperClass(account, "Counter");
-      expect(c.classHash).toEqual(helperClassHash("Counter"));
+      const c = await declareHelperClass(account, helperClassNames.Counter);
+      expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
     },
     default_timeout
   );
@@ -57,8 +59,8 @@ describe("sessionkey management", () => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[0];
-      const c = await declareFailedClass(a, "FailedAccount");
-      expect(c.classHash).toEqual(failedClassHash("FailedAccount"));
+      const c = await declareFailedClass(a, classNames.FailedAccount);
+      expect(c.classHash).toEqual(failedClassHash(classNames.FailedAccount));
     },
     default_timeout
   );
@@ -91,7 +93,7 @@ describe("sessionkey management", () => {
       const publicKey = conf.accounts[0].publicKey;
       const address = await deployAccount(
         failedAccount,
-        "FailedAccount",
+        classNames.FailedAccount,
         publicKey,
         [publicKey]
       );
@@ -177,9 +179,8 @@ describe("sessionkey management", () => {
       );
       try {
         const { transaction_hash } = await counterWithFailedAccount.increment();
-        const receipt = await failedAccount.waitForTransaction(
-          transaction_hash
-        );
+        const receipt =
+          await failedAccount.waitForTransaction(transaction_hash);
         expect(true).toBe(false);
       } catch (e) {
         expect(e).toBeDefined();

--- a/experiments/starknet-failed-account/src/failed_account.ts
+++ b/experiments/starknet-failed-account/src/failed_account.ts
@@ -1,7 +1,7 @@
 import { Account, CallData } from "starknet";
 import { ABI as AccountABI } from "./abi/FailedAccount";
 import { accountAddress, deployAccount } from "./contract";
-
+import { classNames } from "./class";
 /**
  * Generates a failed account address based on the provided public key.
  * @param publicKey - The public key associated with the account.
@@ -11,7 +11,7 @@ export const failedAccountAddress = (publicKey: string): string => {
   const calldata = new CallData(AccountABI).compile("constructor", {
     public_key: publicKey,
   });
-  return accountAddress("FailedAccount", publicKey, calldata);
+  return accountAddress(classNames.FailedAccount, publicKey, calldata);
 };
 
 /**
@@ -30,7 +30,7 @@ export const deployFailedAccount = async (
   });
   return await deployAccount(
     deployerAccount,
-    "FailedAccount",
+    classNames.FailedAccount,
     publicKey,
     callData
   );

--- a/experiments/starknet-failed-account/tsconfig.json
+++ b/experiments/starknet-failed-account/tsconfig.json
@@ -4,9 +4,13 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "references": [{ "path": "../../sdks/__tests__/helpers" }],
+  "references": [
+    { "path": "../../sdks/__tests__/helpers" },
+    { "path": "../../sdks/account" }
+  ],
   "typedocOptions": {
     "entryPoints": ["src/index.ts"],
     "out": "docs",
     "plugin": "typedoc-plugin-markdown"
-  }}
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/node": "^22.10.6",
         "abi-wan-kanabi": "^2.2.4",
         "jest": "^29.7.0",
-        "starknet": "^6.21.0",
+        "starknet": "^6.21.1",
         "ts-jest": "^29.2.5",
         "typedoc": "^0.27.6",
         "typedoc-plugin-markdown": "^4.4.1",
@@ -33,10 +33,11 @@
       }
     },
     "experiments/starknet-bootstrap-account": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "@0xknwn/starknet-test-helpers": "^0.2.1"
+        "@0xknwn/starknet-modular-account": "^0.2.2",
+        "@0xknwn/starknet-test-helpers": "^0.2.2"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -49,10 +50,11 @@
       }
     },
     "experiments/starknet-failed-account": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
-        "@0xknwn/starknet-test-helpers": "^0.2.1"
+        "@0xknwn/starknet-modular-account": "^0.2.2",
+        "@0xknwn/starknet-test-helpers": "^0.2.2"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -85,6 +87,7 @@
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -94,12 +97,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.2",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -107,30 +112,32 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
-      "integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
-      "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
+      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.5",
-        "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-module-transforms": "^7.24.5",
-        "@babel/helpers": "^7.24.5",
-        "@babel/parser": "^7.24.5",
-        "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.5",
-        "@babel/types": "^7.24.5",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.7",
+        "@babel/parser": "^7.26.7",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -145,30 +152,43 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/generator": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
-      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.5",
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -176,63 +196,40 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
-      "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.0"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
-      "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.24.3",
-        "@babel/helper-simple-access": "^7.24.5",
-        "@babel/helper-split-export-declaration": "^7.24.5",
-        "@babel/helper-validator-identifier": "^7.24.5"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -242,170 +239,68 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
-      "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
-      "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.24.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
-      "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.24.5"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
-      "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
+      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.5",
-        "@babel/types": "^7.24.5"
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.7"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
+      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.7"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -418,6 +313,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -430,6 +326,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -442,8 +339,41 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -454,6 +384,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -466,6 +397,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -474,12 +406,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
-      "integrity": "sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -493,6 +426,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -505,6 +439,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -517,6 +452,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -529,6 +465,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -541,6 +478,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -553,8 +491,25 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -565,6 +520,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -576,12 +532,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
-      "integrity": "sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -591,33 +548,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
-      "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/parser": "^7.24.0",
-        "@babel/types": "^7.24.0"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
-      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
+      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.5",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.24.5",
-        "@babel/parser": "^7.24.5",
-        "@babel/types": "^7.24.5",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.7",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -625,15 +581,25 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
-      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.1",
-        "@babel/helper-validator-identifier": "^7.24.5",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -643,7 +609,8 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -689,6 +656,30 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/core": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
@@ -726,43 +717,34 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^2.0.1"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.18.0.tgz",
-      "integrity": "sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
+      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -794,14 +776,14 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.0.tgz",
-      "integrity": "sha512-nFZkbq4/wU+GxkyJVrXeMIS9SEcHI1HzJtK3EDtMQy16nNs1LNaI0dZTLAP2EuK/QSTYLo/Zaabm6Phxlmra1A==",
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
+      "integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^1.27.0",
-        "@shikijs/types": "^1.27.0",
+        "@shikijs/engine-oniguruma": "^1.27.2",
+        "@shikijs/types": "^1.27.2",
         "@shikijs/vscode-textmate": "^10.0.1"
       }
     },
@@ -876,6 +858,7 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
@@ -887,11 +870,102 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -901,6 +975,7 @@
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
       "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -918,6 +993,7 @@
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
       "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/reporters": "^29.7.0",
@@ -965,6 +1041,7 @@
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -980,6 +1057,7 @@
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "expect": "^29.7.0",
         "jest-snapshot": "^29.7.0"
@@ -993,6 +1071,7 @@
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
       },
@@ -1005,6 +1084,7 @@
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -1022,6 +1102,7 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -1037,6 +1118,7 @@
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
       "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "^29.7.0",
@@ -1080,6 +1162,7 @@
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -1092,6 +1175,7 @@
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
       "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
@@ -1106,6 +1190,7 @@
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
       "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -1121,6 +1206,7 @@
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "graceful-fs": "^4.2.9",
@@ -1136,6 +1222,7 @@
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -1162,6 +1249,7 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1175,10 +1263,11 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1193,6 +1282,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1202,33 +1292,36 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.6.0"
+        "@noble/hashes": "1.7.1"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1238,9 +1331,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1311,21 +1404,63 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.27.2.tgz",
-      "integrity": "sha512-FZYKD1KN7srvpkz4lbGLOYWlyDU4Rd+2RtuKfABTkafAPOFr+J6umfIwY/TzOQqfNtWjL7SAwPAO0dcOraRLaQ==",
+    "node_modules/@scure/starknet/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.27.2",
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.1.tgz",
+      "integrity": "sha512-gSt2WhLNgEeLstcweQOSp+C+MhOpTsgdNXRqr3zP6M+BUBZ8Md9OU2BYwUYsALBxHza7hwaIWtFHjQ/aOOychw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.1",
         "@shikijs/vscode-textmate": "^10.0.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.27.2.tgz",
-      "integrity": "sha512-DM9OWUyjmdYdnKDpaGB/GEn9XkToyK1tqxuqbmc5PV+5K8WjjwfygL3+cIvbkSw2v1ySwHDgqATq/+98pJ4Kyg==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.1.tgz",
+      "integrity": "sha512-aBqAuhYRp5vSir3Pc9+QPu9WESBOjUo03ao0IHLC4TyTioSsp/SkbAZSrIH4ghYYC1T1KTEpRSBa83bas4RnPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1344,13 +1479,15 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -1360,6 +1497,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -1369,6 +1507,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -1382,6 +1521,7 @@
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
       "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -1391,16 +1531,18 @@
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
-      "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+      "integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
@@ -1417,6 +1559,7 @@
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1435,13 +1578,15 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -1451,6 +1596,7 @@
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -1474,9 +1620,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
-      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
+      "version": "22.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1487,7 +1633,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1497,10 +1644,11 @@
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -1509,20 +1657,21 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.20.0.tgz",
-      "integrity": "sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.22.0.tgz",
+      "integrity": "sha512-4Uta6REnz/xEJMvwf72wdUnC3rr4jAQf5jnTkeRQ9b6soxLxhDEbS/pfMPoJLDfFPNVRdryqWUIV/2GZzDJFZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.20.0",
-        "@typescript-eslint/type-utils": "8.20.0",
-        "@typescript-eslint/utils": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0",
+        "@typescript-eslint/scope-manager": "8.22.0",
+        "@typescript-eslint/type-utils": "8.22.0",
+        "@typescript-eslint/utils": "8.22.0",
+        "@typescript-eslint/visitor-keys": "8.22.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1542,16 +1691,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.20.0.tgz",
-      "integrity": "sha512-gKXG7A5HMyjDIedBi6bUrDcun8GIjnI8qOwVLiY3rx6T/sHP/19XLJOnIq/FgQvWLHja5JN/LSE7eklNBr612g==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.22.0.tgz",
+      "integrity": "sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.20.0",
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/typescript-estree": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0",
+        "@typescript-eslint/scope-manager": "8.22.0",
+        "@typescript-eslint/types": "8.22.0",
+        "@typescript-eslint/typescript-estree": "8.22.0",
+        "@typescript-eslint/visitor-keys": "8.22.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1567,14 +1716,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.20.0.tgz",
-      "integrity": "sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.22.0.tgz",
+      "integrity": "sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0"
+        "@typescript-eslint/types": "8.22.0",
+        "@typescript-eslint/visitor-keys": "8.22.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1585,14 +1734,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.20.0.tgz",
-      "integrity": "sha512-bPC+j71GGvA7rVNAHAtOjbVXbLN5PkwqMvy1cwGeaxUoRQXVuKCebRoLzm+IPW/NtFFpstn1ummSIasD5t60GA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.22.0.tgz",
+      "integrity": "sha512-NzE3aB62fDEaGjaAYZE4LH7I1MUwHooQ98Byq0G0y3kkibPJQIXVUspzlFOmOfHhiDLwKzMlWxaNv+/qcZurJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.20.0",
-        "@typescript-eslint/utils": "8.20.0",
+        "@typescript-eslint/typescript-estree": "8.22.0",
+        "@typescript-eslint/utils": "8.22.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.0"
       },
@@ -1609,9 +1758,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.20.0.tgz",
-      "integrity": "sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.22.0.tgz",
+      "integrity": "sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1623,14 +1772,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.20.0.tgz",
-      "integrity": "sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.22.0.tgz",
+      "integrity": "sha512-SJX99NAS2ugGOzpyhMza/tX+zDwjvwAtQFLsBo3GQxiGcvaKlqGBkmZ+Y1IdiSi9h4Q0Lr5ey+Cp9CGWNY/F/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0",
+        "@typescript-eslint/types": "8.22.0",
+        "@typescript-eslint/visitor-keys": "8.22.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1649,56 +1798,17 @@
         "typescript": ">=4.8.4 <5.8.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.20.0.tgz",
-      "integrity": "sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.22.0.tgz",
+      "integrity": "sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.20.0",
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/typescript-estree": "8.20.0"
+        "@typescript-eslint/scope-manager": "8.22.0",
+        "@typescript-eslint/types": "8.22.0",
+        "@typescript-eslint/typescript-estree": "8.22.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1713,13 +1823,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.20.0.tgz",
-      "integrity": "sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.22.0.tgz",
+      "integrity": "sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/types": "8.22.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -1804,6 +1914,7 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -1819,6 +1930,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1828,6 +1940,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1842,13 +1955,15 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -1858,13 +1973,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -1878,6 +1991,7 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -1899,6 +2013,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -1915,6 +2030,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
         "@babel/parser": "^7.14.7",
@@ -1926,11 +2042,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -1942,23 +2069,27 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -1969,6 +2100,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0"
@@ -1984,7 +2116,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2008,13 +2141,13 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -2031,9 +2164,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
       "funding": [
         {
@@ -2049,11 +2182,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2067,6 +2201,7 @@
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-json-stable-stringify": "2.x"
       },
@@ -2079,6 +2214,7 @@
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
       }
@@ -2112,13 +2248,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2128,14 +2266,15 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001617",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
-      "integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
+      "version": "1.0.30001695",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
       "dev": true,
       "funding": [
         {
@@ -2150,13 +2289,15 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -2170,6 +2311,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2186,6 +2328,7 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -2201,21 +2344,24 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
-      "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2230,6 +2376,7 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -2239,13 +2386,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2257,25 +2406,29 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
       "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
@@ -2308,12 +2461,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2329,6 +2483,7 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
       "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -2350,6 +2505,7 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2359,6 +2515,7 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2368,6 +2525,7 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -2389,16 +2547,18 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.761",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.761.tgz",
-      "integrity": "sha512-PIbxpiJGx6Bb8dQaonNc6CGTRlVntdLg/2nMa1YhnrwYOORY9a3ZgGN0UQYE6lAcj/lkyduJN7BPt/JiY+jAQQ==",
-      "dev": true
+      "version": "1.5.88",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
+      "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2410,7 +2570,8 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -2430,32 +2591,38 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz",
-      "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
+      "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2464,7 +2631,7 @@
         "@eslint/config-array": "^0.19.0",
         "@eslint/core": "^0.10.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.18.0",
+        "@eslint/js": "9.19.0",
         "@eslint/plugin-kit": "^0.2.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -2555,17 +2722,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -2581,53 +2746,17 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -2666,6 +2795,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2725,6 +2855,7 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -2757,6 +2888,7 @@
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
         "jest-get-type": "^29.6.3",
@@ -2809,7 +2941,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -2833,6 +2966,7 @@
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
       }
@@ -2842,6 +2976,7 @@
       "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-3.0.1.tgz",
       "integrity": "sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==",
       "dev": true,
+      "license": "Unlicense",
       "dependencies": {
         "set-cookie-parser": "^2.4.8",
         "tough-cookie": "^4.0.0"
@@ -2868,16 +3003,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -2907,16 +3032,20 @@
       }
     },
     "node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "locate-path": "^5.0.0",
+        "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat-cache": {
@@ -2945,6 +3074,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2958,7 +3088,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2966,6 +3097,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2979,6 +3111,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2988,6 +3121,7 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2997,6 +3131,7 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -3006,6 +3141,7 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3015,6 +3151,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3026,7 +3163,9 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3055,20 +3194,49 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
       "engines": {
-        "node": ">=4"
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3082,6 +3250,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3091,6 +3260,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3102,13 +3272,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
       }
@@ -3161,21 +3333,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/import-local": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
-      "dev": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -3195,6 +3358,7 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -3203,7 +3367,9 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3213,21 +3379,27 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3248,6 +3420,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3257,6 +3430,7 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3289,6 +3463,7 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -3300,13 +3475,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
       "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
@@ -3317,15 +3494,17 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
-      "integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -3337,23 +3516,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
-      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -3368,6 +3536,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
       "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
@@ -3382,6 +3551,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
       "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -3409,11 +3579,36 @@
         "node": ">=10"
       }
     },
+    "node_modules/jake/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jake/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3440,6 +3635,7 @@
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
       "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
         "jest-util": "^29.7.0",
@@ -3454,6 +3650,7 @@
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
       "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -3485,6 +3682,7 @@
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
       "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/test-result": "^29.7.0",
@@ -3518,6 +3716,7 @@
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/test-sequencer": "^29.7.0",
@@ -3563,6 +3762,7 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -3578,6 +3778,7 @@
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -3590,6 +3791,7 @@
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
       "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
@@ -3606,6 +3808,7 @@
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -3623,6 +3826,7 @@
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3632,6 +3836,7 @@
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3657,6 +3862,7 @@
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3",
         "pretty-format": "^29.7.0"
@@ -3670,6 +3876,7 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.7.0",
@@ -3685,6 +3892,7 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -3705,6 +3913,7 @@
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3719,6 +3928,7 @@
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -3736,6 +3946,7 @@
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3745,6 +3956,7 @@
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
@@ -3765,6 +3977,7 @@
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
       "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.6.3",
         "jest-snapshot": "^29.7.0"
@@ -3778,6 +3991,7 @@
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/environment": "^29.7.0",
@@ -3810,6 +4024,7 @@
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -3843,6 +4058,7 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
@@ -3869,23 +4085,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
-      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -3903,6 +4108,7 @@
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
@@ -3920,6 +4126,7 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3932,6 +4139,7 @@
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -3951,6 +4159,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "jest-util": "^29.7.0",
@@ -3966,6 +4175,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3980,31 +4190,33 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -4018,7 +4230,8 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4039,6 +4252,7 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -4051,6 +4265,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4073,6 +4288,7 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4082,6 +4298,7 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4104,7 +4321,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
@@ -4117,22 +4335,27 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4142,16 +4365,18 @@
       "license": "MIT"
     },
     "node_modules/lossless-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.1.tgz",
-      "integrity": "sha512-l0L+ppmgPDnb+JGxNLndPtJZGNf6+ZmVaQzoxQm3u6TXmhdnsA+YtdVR8DjzZd/em58686CQhOFDPewfJ4l7MA==",
-      "dev": true
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.2.tgz",
+      "integrity": "sha512-+z0EaLi2UcWi8MZRxA5iTb6m4Ys4E80uftGY+yG5KNFJb5EceQXOhdW/pWJZ8m97s26u7yZZAYMcKWNztSZssA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -4160,13 +4385,15 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -4177,29 +4404,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
-      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
       }
@@ -4222,13 +4439,6 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -4240,7 +4450,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4271,39 +4482,47 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4323,19 +4542,22 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4345,6 +4567,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -4357,6 +4580,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -4366,6 +4590,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -4399,6 +4624,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -4410,27 +4636,16 @@
       }
     },
     "node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4441,6 +4656,7 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4449,7 +4665,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "dev": true
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4469,6 +4686,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -4487,6 +4705,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4496,6 +4715,7 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4505,6 +4725,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4513,19 +4734,22 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -4538,6 +4762,7 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -4547,8 +4772,65 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
       },
       "engines": {
         "node": ">=8"
@@ -4585,6 +4867,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -4599,6 +4882,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4611,6 +4895,7 @@
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -4620,16 +4905,24 @@
       }
     },
     "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4658,13 +4951,15 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fast-check"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4691,13 +4986,15 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esprima": "~4.0.0"
       }
@@ -4707,6 +5004,7 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4715,20 +5013,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4739,6 +5042,7 @@
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -4746,20 +5050,32 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-from": {
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/resolve.exports": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
-      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -4800,25 +5116,31 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
-      "dev": true
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4831,6 +5153,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4839,19 +5162,22 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4861,6 +5187,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4870,6 +5197,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4879,13 +5207,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -4893,10 +5223,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/starknet": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-6.21.0.tgz",
-      "integrity": "sha512-xUSlqyE+J/S5un3TyQY0Kehilh1u7ewPaut87eOxTDS1r90SU0QvQ3JEECp5LbW/sqsaMhfb+tGTBGrKzXg7bg==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-6.21.1.tgz",
+      "integrity": "sha512-bmhGGsF8rAZWzWzkQAtkzHfmzy4Nc9pFRKVQo/i+sd2TQqRiOnVM5kK9suEbpveTGd/Ko9zGHmrjofE49hZOng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4929,11 +5269,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/starknet/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
@@ -4947,6 +5317,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4961,6 +5332,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4973,6 +5345,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4982,6 +5355,7 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4991,6 +5365,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -5003,6 +5378,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5015,6 +5391,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5027,6 +5404,7 @@
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
@@ -5034,6 +5412,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tests-module": {
@@ -5056,16 +5458,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
+      "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5085,6 +5479,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -5100,6 +5495,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -5108,7 +5504,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.0.0",
@@ -5172,24 +5569,12 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
       "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5209,6 +5594,7 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -5218,6 +5604,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -5261,32 +5648,6 @@
         "typedoc": "0.27.x"
       }
     },
-    "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
@@ -5320,14 +5681,15 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz",
-      "integrity": "sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "dev": true,
       "funding": [
         {
@@ -5343,9 +5705,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -5369,16 +5732,18 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -5393,6 +5758,7 @@
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
       }
@@ -5401,19 +5767,22 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5424,6 +5793,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5449,6 +5819,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5465,13 +5836,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -5485,6 +5858,7 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -5493,7 +5867,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.7.0",
@@ -5513,6 +5888,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -5531,6 +5907,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -5540,6 +5917,7 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -56,6 +57,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -1984,6 +1986,27 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2058,6 +2081,31 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -3064,6 +3112,27 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5480,7 +5549,7 @@
     },
     "sdks/__tests__/account": {
       "name": "tests-starknet-account",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@0xknwn/starknet-test-helpers": "^0.2.1"
@@ -5488,6 +5557,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -5496,11 +5566,12 @@
     },
     "sdks/__tests__/helpers": {
       "name": "@0xknwn/starknet-test-helpers",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -5509,7 +5580,7 @@
     },
     "sdks/__tests__/module": {
       "name": "tests-module",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@0xknwn/starknet-test-helpers": "^0.2.1",
@@ -5518,6 +5589,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -5526,7 +5598,7 @@
     },
     "sdks/__tests__/module-guarded": {
       "name": "tests-module-guarded",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@0xknwn/starknet-test-helpers": "^0.2.1",
@@ -5535,6 +5607,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -5543,7 +5616,7 @@
     },
     "sdks/__tests__/module-sessionkey": {
       "name": "tests-module-sessionkey",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@0xknwn/starknet-test-helpers": "^0.2.1"
@@ -5551,6 +5624,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -5559,11 +5633,12 @@
     },
     "sdks/account": {
       "name": "@0xknwn/starknet-modular-account",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -5572,11 +5647,12 @@
     },
     "sdks/module": {
       "name": "@0xknwn/starknet-module",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",
@@ -5585,11 +5661,12 @@
     },
     "sdks/module-sessionkey": {
       "name": "@0xknwn/starknet-module-sessionkey",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
         "@typescript-eslint/parser": "^8.20.0",
+        "buffer": "^6.0.3",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "prettier": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/node": "^22.10.6",
     "abi-wan-kanabi": "^2.2.4",
     "jest": "^29.7.0",
-    "starknet": "^6.21.0",
+    "starknet": "^6.21.1",
     "ts-jest": "^29.2.5",
     "typedoc": "^0.27.6",
     "typedoc-plugin-markdown": "^4.4.1",

--- a/sdks/__tests__/account/package.json
+++ b/sdks/__tests__/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-starknet-account",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "scripts": {
     "test": "jest --runInBand --verbose"
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/sdks/__tests__/account/src/module.test.ts
+++ b/sdks/__tests__/account/src/module.test.ts
@@ -14,9 +14,13 @@ import {
   deployAccount,
   accountAddress,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, CallData } from "starknet";
-import { StarkValidatorABI, classNames } from "@0xknwn/starknet-modular-account";
+import {
+  StarkValidatorABI,
+  classNames,
+} from "@0xknwn/starknet-modular-account";
 import { data } from "./data.fixture";
 
 describe.each(data)("module management", ({ fees, version, accountID }) => {
@@ -61,12 +65,18 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
       const p = new RpcProvider({ nodeUrl: conf.providerURL });
       const publicKey = conf.accounts[accountID].publicKey;
       const privateKey = conf.accounts[accountID].privateKey;
-      const starkValidatorClassHash = accountClassHash(classNames.StarkValidator);
+      const starkValidatorClassHash = accountClassHash(
+        classNames.StarkValidator
+      );
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
       });
-      const address = accountAddress("SmartrAccount", publicKey, calldata);
+      const address = accountAddress(
+        accountClassNames.SmartrAccount,
+        publicKey,
+        calldata
+      );
       const TOKEN = fees === "WEI" ? ETH : STRK;
       const initial_transfer =
         fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -93,20 +103,22 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const publicKey = conf.accounts[accountID].publicKey;
-      const starkValidatorClassHash = accountClassHash(classNames.StarkValidator);
+      const starkValidatorClassHash = accountClassHash(
+        classNames.StarkValidator
+      );
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
       });
       const address = await deployAccount(
         smartrAccount,
-        "SmartrAccount",
+        accountClassNames.SmartrAccount,
         publicKey,
         calldata,
         { version: version.deploy_account }
       );
       expect(address).toEqual(
-        accountAddress("SmartrAccount", publicKey, calldata)
+        accountAddress(accountClassNames.SmartrAccount, publicKey, calldata)
       );
     },
     default_timeout
@@ -192,7 +204,9 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       try {
-        await smartrAccount.addModule(accountClassHash(classNames.SimpleValidator));
+        await smartrAccount.addModule(
+          accountClassHash(classNames.SimpleValidator)
+        );
         expect(true).toBe(false);
       } catch (e) {
         expect(e).toBeDefined();

--- a/sdks/__tests__/account/src/module.test.ts
+++ b/sdks/__tests__/account/src/module.test.ts
@@ -16,7 +16,7 @@ import {
   SmartrAccountABI,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, CallData } from "starknet";
-import { StarkValidatorABI } from "@0xknwn/starknet-modular-account";
+import { StarkValidatorABI, classNames } from "@0xknwn/starknet-modular-account";
 import { data } from "./data.fixture";
 
 describe.each(data)("module management", ({ fees, version, accountID }) => {
@@ -32,10 +32,10 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "StarkValidator", {
+      const c = await declareAccountClass(a, classNames.StarkValidator, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(accountClassHash("StarkValidator"));
+      expect(c.classHash).toEqual(accountClassHash(classNames.StarkValidator));
     },
     default_timeout
   );
@@ -45,10 +45,10 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "SmartrAccount", {
+      const c = await declareAccountClass(a, classNames.SmartrAccount, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+      expect(c.classHash).toEqual(accountClassHash(classNames.SmartrAccount));
     },
     default_timeout
   );
@@ -61,7 +61,7 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
       const p = new RpcProvider({ nodeUrl: conf.providerURL });
       const publicKey = conf.accounts[accountID].publicKey;
       const privateKey = conf.accounts[accountID].privateKey;
-      const starkValidatorClassHash = accountClassHash("StarkValidator");
+      const starkValidatorClassHash = accountClassHash(classNames.StarkValidator);
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
@@ -93,7 +93,7 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const publicKey = conf.accounts[accountID].publicKey;
-      const starkValidatorClassHash = accountClassHash("StarkValidator");
+      const starkValidatorClassHash = accountClassHash(classNames.StarkValidator);
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
@@ -120,7 +120,7 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
       const calldata = new CallData(StarkValidatorABI);
       const data = calldata.compile("get_public_key", {});
       const c = await smartrAccount.callOnModule(
-        accountClassHash("StarkValidator"),
+        accountClassHash(classNames.StarkValidator),
         "get_public_key",
         data
       );
@@ -150,8 +150,8 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "SimpleValidator");
-      expect(c.classHash).toEqual(accountClassHash("SimpleValidator"));
+      const c = await declareAccountClass(a, classNames.SimpleValidator);
+      expect(c.classHash).toEqual(accountClassHash(classNames.SimpleValidator));
     },
     default_timeout
   );
@@ -163,7 +163,7 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       const { transaction_hash } = await smartrAccount.addModule(
-        accountClassHash("SimpleValidator")
+        accountClassHash(classNames.SimpleValidator)
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
@@ -178,7 +178,7 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       const output = await smartrAccount.isModule(
-        accountClassHash("SimpleValidator")
+        accountClassHash(classNames.SimpleValidator)
       );
       expect(output).toBe(true);
     },
@@ -192,7 +192,7 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       try {
-        await smartrAccount.addModule(accountClassHash("SimpleValidator"));
+        await smartrAccount.addModule(accountClassHash(classNames.SimpleValidator));
         expect(true).toBe(false);
       } catch (e) {
         expect(e).toBeDefined();
@@ -208,7 +208,7 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       const { transaction_hash } = await smartrAccount.removeModule(
-        accountClassHash("SimpleValidator")
+        accountClassHash(classNames.SimpleValidator)
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
@@ -223,7 +223,7 @@ describe.each(data)("module management", ({ fees, version, accountID }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       const output = await smartrAccount.isModule(
-        accountClassHash("SimpleValidator")
+        accountClassHash(classNames.SimpleValidator)
       );
       expect(output).toBe(false);
     },

--- a/sdks/__tests__/account/src/smartr_account.test.ts
+++ b/sdks/__tests__/account/src/smartr_account.test.ts
@@ -11,6 +11,7 @@ import {
   initial_StrkTransfer,
   ETH,
   STRK,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -19,6 +20,7 @@ import {
   deployAccount,
   accountAddress,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, CallData, Contract, shortString, num } from "starknet";
 import { StarkValidatorABI } from "@0xknwn/starknet-modular-account";
@@ -38,8 +40,10 @@ describe.each(data)("account management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const account = testAccounts(conf)[accountID];
-      const c = await declareHelperClass(account, "Counter", {version: version.declare});
-      expect(c.classHash).toEqual(helperClassHash("Counter"));
+      const c = await declareHelperClass(account, helperClassNames.Counter, {
+        version: version.declare,
+      });
+      expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
     },
     default_timeout
   );
@@ -49,7 +53,9 @@ describe.each(data)("account management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const account = testAccounts(conf)[accountID];
-      const c = await deployCounter(account, account.address, {version: version.invoke});
+      const c = await deployCounter(account, account.address, {
+        version: version.invoke,
+      });
       expect(c.address).toEqual(
         await counterAddress(account.address, account.address)
       );
@@ -63,8 +69,12 @@ describe.each(data)("account management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "StarkValidator", {version: version.declare});
-      expect(c.classHash).toEqual(accountClassHash("StarkValidator"));
+      const c = await declareAccountClass(a, accountClassNames.StarkValidator, {
+        version: version.declare,
+      });
+      expect(c.classHash).toEqual(
+        accountClassHash(accountClassNames.StarkValidator)
+      );
     },
     default_timeout
   );
@@ -74,8 +84,12 @@ describe.each(data)("account management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "SmartrAccount", {version: version.declare});
-      expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+      const c = await declareAccountClass(a, accountClassNames.SmartrAccount, {
+        version: version.declare,
+      });
+      expect(c.classHash).toEqual(
+        accountClassHash(accountClassNames.SmartrAccount)
+      );
     },
     default_timeout
   );
@@ -88,12 +102,18 @@ describe.each(data)("account management", ({ fees, version, accountID }) => {
       const p = new RpcProvider({ nodeUrl: conf.providerURL });
       const publicKey = conf.accounts[accountID].publicKey;
       const privateKey = conf.accounts[accountID].privateKey;
-      const starkValidatorClassHash = accountClassHash("StarkValidator");
+      const starkValidatorClassHash = accountClassHash(
+        accountClassNames.StarkValidator
+      );
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
       });
-      const address = accountAddress("SmartrAccount", publicKey, calldata);
+      const address = accountAddress(
+        accountClassNames.SmartrAccount,
+        publicKey,
+        calldata
+      );
       const TOKEN = fees === "WEI" ? ETH : STRK;
       const initial_transfer =
         fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -120,20 +140,22 @@ describe.each(data)("account management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const publicKey = conf.accounts[accountID].publicKey;
-      const starkValidatorClassHash = accountClassHash("StarkValidator");
+      const starkValidatorClassHash = accountClassHash(
+        accountClassNames.StarkValidator
+      );
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
       });
       const address = await deployAccount(
         smartrAccount,
-        "SmartrAccount",
+        accountClassNames.SmartrAccount,
         publicKey,
         calldata,
         { version: version.deploy_account }
       );
       expect(address).toEqual(
-        accountAddress("SmartrAccount", publicKey, calldata)
+        accountAddress(accountClassNames.SmartrAccount, publicKey, calldata)
       );
     },
     default_timeout
@@ -146,7 +168,7 @@ describe.each(data)("account management", ({ fees, version, accountID }) => {
       const calldata = new CallData(StarkValidatorABI);
       const data = calldata.compile("get_public_key", {});
       const c = await smartrAccount.callOnModule(
-        accountClassHash("StarkValidator"),
+        accountClassHash(accountClassNames.StarkValidator),
         "get_public_key",
         data
       );

--- a/sdks/__tests__/account/src/smartr_validator.test.ts
+++ b/sdks/__tests__/account/src/smartr_validator.test.ts
@@ -14,6 +14,7 @@ import {
   deployAccount,
   accountAddress,
   SmartrAccountABI,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 import { StarkValidatorABI } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, num, CallData, shortString } from "starknet";
@@ -34,10 +35,10 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "StarkValidator", {
+        const c = await declareAccountClass(a, classNames.StarkValidator, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(accountClassHash("StarkValidator"));
+        expect(c.classHash).toEqual(accountClassHash(classNames.StarkValidator));
       },
       default_timeout
     );
@@ -47,10 +48,10 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount", {
+        const c = await declareAccountClass(a, classNames.SmartrAccount, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        expect(c.classHash).toEqual(accountClassHash(classNames.SmartrAccount));
       },
       default_timeout
     );
@@ -63,12 +64,12 @@ describe.each(data)(
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const publicKey = conf.accounts[accountID].publicKey;
         const privateKey = conf.accounts[accountID].privateKey;
-        const starkValidatorClassHash = accountClassHash("StarkValidator");
+        const starkValidatorClassHash = accountClassHash(classNames.StarkValidator);
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
-        const address = accountAddress("SmartrAccount", publicKey, calldata);
+        const address = accountAddress(classNames.SmartrAccount, publicKey, calldata);
         const TOKEN = fees === "WEI" ? ETH : STRK;
         const initial_transfer =
           fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -95,20 +96,20 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const publicKey = conf.accounts[accountID].publicKey;
-        const starkValidatorClassHash = accountClassHash("StarkValidator");
+        const starkValidatorClassHash = accountClassHash(classNames.StarkValidator);
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
         const address = await deployAccount(
           smartrAccount,
-          "SmartrAccount",
+          classNames.SmartrAccount,
           publicKey,
           calldata,
           { version: version.deploy_account }
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", publicKey, calldata)
+          accountAddress(classNames.SmartrAccount, publicKey, calldata)
         );
       },
       default_timeout
@@ -122,7 +123,7 @@ describe.each(data)(
         const calldata = new CallData(StarkValidatorABI);
         const data = calldata.compile("get_name", {});
         const output = await smartrAccount.callOnModule(
-          accountClassHash("StarkValidator"),
+          accountClassHash(classNames.StarkValidator),
           "get_name",
           data
         );

--- a/sdks/__tests__/account/src/smartr_validator.test.ts
+++ b/sdks/__tests__/account/src/smartr_validator.test.ts
@@ -38,7 +38,9 @@ describe.each(data)(
         const c = await declareAccountClass(a, classNames.StarkValidator, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(accountClassHash(classNames.StarkValidator));
+        expect(c.classHash).toEqual(
+          accountClassHash(classNames.StarkValidator)
+        );
       },
       default_timeout
     );
@@ -64,12 +66,18 @@ describe.each(data)(
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const publicKey = conf.accounts[accountID].publicKey;
         const privateKey = conf.accounts[accountID].privateKey;
-        const starkValidatorClassHash = accountClassHash(classNames.StarkValidator);
+        const starkValidatorClassHash = accountClassHash(
+          classNames.StarkValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
-        const address = accountAddress(classNames.SmartrAccount, publicKey, calldata);
+        const address = accountAddress(
+          classNames.SmartrAccount,
+          publicKey,
+          calldata
+        );
         const TOKEN = fees === "WEI" ? ETH : STRK;
         const initial_transfer =
           fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -96,7 +104,9 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const publicKey = conf.accounts[accountID].publicKey;
-        const starkValidatorClassHash = accountClassHash(classNames.StarkValidator);
+        const starkValidatorClassHash = accountClassHash(
+          classNames.StarkValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],

--- a/sdks/__tests__/account/src/upgrade.test.ts
+++ b/sdks/__tests__/account/src/upgrade.test.ts
@@ -9,6 +9,7 @@ import {
   initial_StrkTransfer,
   ETH,
   STRK,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -17,6 +18,7 @@ import {
   deployAccount,
   accountAddress,
   SmartrAccountABI,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, Contract, Account, type Call, CallData } from "starknet";
 import { StarkValidatorABI } from "@0xknwn/starknet-modular-account";
@@ -35,10 +37,12 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareHelperClass(a, "SimpleAccount", {
+      const c = await declareHelperClass(a, helperClassNames.SimpleAccount, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(helperClassHash("SimpleAccount"));
+      expect(c.classHash).toEqual(
+        helperClassHash(helperClassNames.SimpleAccount)
+      );
     },
     default_timeout
   );
@@ -48,10 +52,10 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "StarkValidator", {
+      const c = await declareAccountClass(a, classNames.StarkValidator, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(accountClassHash("StarkValidator"));
+      expect(c.classHash).toEqual(accountClassHash(classNames.StarkValidator));
     },
     default_timeout
   );
@@ -61,10 +65,10 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "SmartrAccount", {
+      const c = await declareAccountClass(a, classNames.SmartrAccount, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+      expect(c.classHash).toEqual(accountClassHash(classNames.SmartrAccount));
     },
     default_timeout
   );
@@ -77,12 +81,18 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
       const p = new RpcProvider({ nodeUrl: conf.providerURL });
       const publicKey = conf.accounts[accountID].publicKey;
       const privateKey = conf.accounts[accountID].privateKey;
-      const starkValidatorClassHash = accountClassHash("StarkValidator");
+      const starkValidatorClassHash = accountClassHash(
+        classNames.StarkValidator
+      );
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
       });
-      const address = accountAddress("SmartrAccount", publicKey, calldata);
+      const address = accountAddress(
+        classNames.SmartrAccount,
+        publicKey,
+        calldata
+      );
       const TOKEN = fees === "WEI" ? ETH : STRK;
       const initial_transfer =
         fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -109,7 +119,9 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const publicKey = conf.accounts[accountID].publicKey;
-      const starkValidatorClassHash = accountClassHash("StarkValidator");
+      const starkValidatorClassHash = accountClassHash(
+        classNames.StarkValidator
+      );
       const x = new CallData(SmartrAccountABI);
       const calldata = x.compile("constructor", {
         core_validator: starkValidatorClassHash,
@@ -117,13 +129,13 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
       });
       const address = await deployAccount(
         smartrAccount,
-        "SmartrAccount",
+        classNames.SmartrAccount,
         publicKey,
         calldata,
         { version: version.deploy_account }
       );
       expect(address).toEqual(
-        accountAddress("SmartrAccount", publicKey, calldata)
+        accountAddress(classNames.SmartrAccount, publicKey, calldata)
       );
     },
     default_timeout
@@ -136,7 +148,7 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
       const calldata = new CallData(StarkValidatorABI);
       const data = calldata.compile("get_public_key", {});
       const c = await smartrAccount.callOnModule(
-        accountClassHash("StarkValidator"),
+        accountClassHash(classNames.StarkValidator),
         "get_public_key",
         data
       );
@@ -153,7 +165,7 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
     `[${fees}] checks the account class hash`,
     async () => {
       const c = await smartrAccount.getClassHashAt(smartrAccount.address);
-      expect(c).toEqual(accountClassHash("SmartrAccount"));
+      expect(c).toEqual(accountClassHash(classNames.SmartrAccount));
     },
     default_timeout
   );
@@ -162,7 +174,7 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
     `[${fees}] upgrades the account with SimpleAccount`,
     async () => {
       const { transaction_hash } = await smartrAccount.upgrade(
-        helperClassHash("SimpleAccount")
+        helperClassHash(helperClassNames.SimpleAccount)
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toEqual(true);
@@ -174,7 +186,7 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
     `[${fees}] checks the account class hash`,
     async () => {
       const c = await smartrAccount.getClassHashAt(smartrAccount.address);
-      expect(c).toEqual(helperClassHash("SimpleAccount"));
+      expect(c).toEqual(helperClassHash(helperClassNames.SimpleAccount));
     },
     default_timeout
   );
@@ -212,7 +224,7 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
         smartrAccount
       );
       const call: Call = contract.populate("upgrade", {
-        new_class_hash: accountClassHash("SmartrAccount"),
+        new_class_hash: accountClassHash(classNames.SmartrAccount),
       });
 
       const { transaction_hash } = await a.execute(call);
@@ -226,7 +238,7 @@ describe.each(data)("upgrade management", ({ fees, version, accountID }) => {
     `[${fees}] checks the account class hash`,
     async () => {
       const c = await smartrAccount.getClassHashAt(smartrAccount.address);
-      expect(c).toEqual(accountClassHash("SmartrAccount"));
+      expect(c).toEqual(accountClassHash(classNames.SmartrAccount));
     },
     default_timeout
   );

--- a/sdks/__tests__/helpers/package.json
+++ b/sdks/__tests__/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-test-helpers",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/sdks/__tests__/helpers/src/class.test.ts
+++ b/sdks/__tests__/helpers/src/class.test.ts
@@ -1,9 +1,9 @@
-import { declareClass, classHash } from "./class";
+import { declareClass, classHash, classNames } from "./class";
 import { default_timeout } from "./parameters";
 import { testAccounts, config } from "./utils";
 import { data } from "./data.fixture";
 
-describe.each([data[1]])("class management", ({fees, version, accountID}) => {
+describe.each([data[1]])("class management", ({ fees, version, accountID }) => {
   const env = "devnet";
 
   it(
@@ -11,8 +11,10 @@ describe.each([data[1]])("class management", ({fees, version, accountID}) => {
     async () => {
       const conf = config(env);
       const account = testAccounts(conf)[accountID];
-      const output = await declareClass(account, "SimpleAccount", {version: version.declare});
-      expect(output.classHash).toEqual(classHash("SimpleAccount"));
+      const output = await declareClass(account, classNames.SimpleAccount, {
+        version: version.declare,
+      });
+      expect(output.classHash).toEqual(classHash(classNames.SimpleAccount));
     },
     default_timeout
   );

--- a/sdks/__tests__/helpers/src/class.ts
+++ b/sdks/__tests__/helpers/src/class.ts
@@ -1,4 +1,5 @@
 import { hash, json, CompiledContract, Account } from "starknet";
+import { Buffer } from "buffer";
 import { data as CounterContract } from "./artifacts/Counter-contract";
 import { data as CounterCompiled } from "./artifacts/Counter-compiled";
 import { data as SimpleAccountContract } from "./artifacts/SimpleAccount-contract";
@@ -19,29 +20,30 @@ import type { UniversalDetails } from "starknet";
  * `scarb build` command at the root of the project.
  *
  */
-export const classHash = (
-  className:
-    | "Counter"
-    | "SimpleAccount"
-    | "SwapRouter"
-    | "TokenA"
-    | "TokenB" = "Counter"
-) => {
+export enum classNames {
+  Counter = "Counter",
+  SimpleAccount = "SimpleAccount",
+  SwapRouter = "SwapRouter",
+  TokenA = "TokenA",
+  TokenB = "TokenB",
+}
+
+export const classHash = (className: classNames = classNames.Counter) => {
   let contract: string = "";
   switch (className) {
-    case "Counter":
+    case classNames.Counter:
       contract = CounterContract;
       break;
-    case "SimpleAccount":
+    case classNames.SimpleAccount:
       contract = SimpleAccountContract;
       break;
-    case "SwapRouter":
+    case classNames.SwapRouter:
       contract = SwapRouterContract;
       break;
-    case "TokenA":
+    case classNames.TokenA:
       contract = TokenAContract;
       break;
-    case "TokenB":
+    case classNames.TokenB:
       contract = TokenBContract;
       break;
     default:
@@ -71,13 +73,8 @@ export const classHash = (
  */
 export const declareClass = async (
   account: Account,
-  className:
-    | "Counter"
-    | "SimpleAccount"
-    | "SwapRouter"
-    | "TokenA"
-    | "TokenB",
-    details?: UniversalDetails,
+  className: classNames,
+  details?: UniversalDetails
 ) => {
   const HelperClassHash = classHash(className);
 
@@ -90,19 +87,19 @@ export const declareClass = async (
 
   let contract: string = "";
   switch (className) {
-    case "Counter":
+    case classNames.Counter:
       contract = CounterContract;
       break;
-    case "SimpleAccount":
+    case classNames.SimpleAccount:
       contract = SimpleAccountContract;
       break;
-    case "SwapRouter":
+    case classNames.SwapRouter:
       contract = SwapRouterContract;
       break;
-    case "TokenA":
+    case classNames.TokenA:
       contract = TokenAContract;
       break;
-    case "TokenB":
+    case classNames.TokenB:
       contract = TokenBContract;
       break;
     default:
@@ -111,19 +108,19 @@ export const declareClass = async (
 
   let compiled: string = "";
   switch (className) {
-    case "Counter":
+    case classNames.Counter:
       compiled = CounterCompiled;
       break;
-    case "SimpleAccount":
+    case classNames.SimpleAccount:
       compiled = SimpleAccountCompiled;
       break;
-    case "SwapRouter":
+    case classNames.SwapRouter:
       compiled = SwapRouterCompiled;
       break;
-    case "TokenA":
+    case classNames.TokenA:
       compiled = TokenACompiled;
       break;
-    case "TokenB":
+    case classNames.TokenB:
       compiled = TokenBCompiled;
       break;
     default:
@@ -136,10 +133,13 @@ export const declareClass = async (
   const compiledTestCasm = json.parse(
     Buffer.from(compiled, "base64").toString("ascii")
   );
-  const declare = await account.declare({
-    contract: compiledTestSierra,
-    casm: compiledTestCasm,
-  }, details);
+  const declare = await account.declare(
+    {
+      contract: compiledTestSierra,
+      casm: compiledTestCasm,
+    },
+    details
+  );
   return {
     ...(await account.waitForTransaction(declare.transaction_hash)),
     classHash: declare.class_hash,

--- a/sdks/__tests__/helpers/src/contract.test.ts
+++ b/sdks/__tests__/helpers/src/contract.test.ts
@@ -1,4 +1,4 @@
-import { classHash } from "./class";
+import { classHash, classNames } from "./class";
 import { default_timeout } from "./parameters";
 import { hash } from "starknet";
 import { config } from "./utils";
@@ -21,7 +21,7 @@ describe.each(data)("contract management (helper)", ({fees, version, accountID})
       const conf = config(env);
             
       const publicKey = conf.accounts[accountID].publicKey;
-      const class_hash = classHash("SimpleAccount");
+      const class_hash = classHash(classNames.SimpleAccount);
       expect(class_hash).toBe(
         expected.SimpleAccountClassHash
       );

--- a/sdks/__tests__/helpers/src/contract.ts
+++ b/sdks/__tests__/helpers/src/contract.ts
@@ -1,4 +1,4 @@
-import { classHash } from "./class";
+import { classHash, classNames } from "./class";
 import { Contract, Account, hash, ec } from "starknet";
 import { udcAddress, ETH, STRK } from "./natives";
 import { initial_EthTransfer, initial_StrkTransfer } from "./parameters";
@@ -13,7 +13,7 @@ import type { Abi, UniversalDetails } from "starknet";
  * @returns The contract address.
  */
 export const contractAddress = async (
-  contractName: "Counter" | "SwapRouter" | "TokenA" | "TokenB",
+  contractName: classNames,
   deployerAddress: string,
   constructorCallData: string[]
 ): Promise<string> => {
@@ -38,7 +38,7 @@ export const contractAddress = async (
  * `scarb build` command at the root of the project.
  */
 export const accountAddress = (
-  accountName: "SimpleAccount",
+  accountName: classNames.SimpleAccount,
   publicKey: string,
   constructorCallData: string[]
 ): string => {
@@ -60,7 +60,11 @@ export const accountAddress = (
  * @returns A Promise that resolves to a Contract instance representing the deployed contract.
  */
 export const deployContract = async (
-  contractName: "Counter" | "SwapRouter" | "TokenA" | "TokenB" = "Counter",
+  contractName:
+    | classNames.Counter
+    | classNames.SwapRouter
+    | classNames.TokenA
+    | classNames.TokenB = classNames.Counter,
   ABI: Abi,
   deployerAccount: Account,
   constructorCalldata: any[],
@@ -105,7 +109,7 @@ export const deployContract = async (
  */
 export const deployAccount = async (
   deployerAccount: Account,
-  accountName: "SimpleAccount",
+  accountName: classNames.SimpleAccount,
   publicKey: string,
   constructorCalldata: any[],
   details?: UniversalDetails

--- a/sdks/__tests__/helpers/src/counter.test.ts
+++ b/sdks/__tests__/helpers/src/counter.test.ts
@@ -1,227 +1,253 @@
-import { declareClass, classHash } from "./class";
+import { declareClass, classHash, classNames } from "./class";
 import { testAccounts, config } from "./utils";
 import { deployCounter, counterAddress, CounterABI } from "./counter";
 import { default_timeout } from "./parameters";
-import { Contract, type Call, RpcProvider, Account, UniversalDetails } from "starknet";
+import {
+  Contract,
+  type Call,
+  RpcProvider,
+  Account,
+  UniversalDetails,
+} from "starknet";
 
 import { data } from "./data.fixture";
-  
-describe.each(data)("counter contract (helper)", ({ fees, version, accountID }) => {
-  let env: string;
-  let counter: Contract;
-  let altURL: string;
-  const redeployCounter = async (account: Account, details?: UniversalDetails) => {
-    if (!counter) {
-      counter = await deployCounter(account, account.address, details);
-    }
-  }
-  
-  beforeAll(() => {
-    env = "devnet";
-    const conf = config(env);
-    // altURL = "http://localhost:8080";
-    if (!altURL) {
-      altURL = conf.providerURL;
-    }
-  });
 
-  it(
-    `[${fees}] declare the Counter class`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      const c = await declareClass(account, "Counter", {version: version.declare});
-      expect(c.classHash).toEqual(classHash("Counter"));
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] deploys the Counter contract`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      const c = await deployCounter(account, account.address, {version: version.invoke});
-      expect(c.address).toEqual(
-        await counterAddress(account.address, account.address)
-      );
-      counter = c;
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] increments the counter`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const transferCall: Call = counter.populate("increment", {});
-      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
-      const receipt = await account.waitForTransaction(transaction_hash);
-      expect(receipt.isSuccess()).toBe(true);
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] reads the counter`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const c = await counter.get();
-      expect(c).toBeGreaterThan(0n);
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] increments the counter by 5 and 6`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const transferCall: Call = counter.populate("increment_by_array", {
-        args: [5, 6],
-      });
-      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
-      const receipt = await account.waitForTransaction(transaction_hash);
-      expect(receipt.isSuccess()).toBe(true);
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] reads the counter again`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const c = await counter.get();
-      expect(c).toBeGreaterThan(11n);
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] resets the counter`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const transferCall: Call = counter.populate("reset", {});
-      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
-      const receipt = await account.waitForTransaction(transaction_hash);
-      expect(receipt.isSuccess()).toBe(true);
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] reads the counter again`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const c = await counter.get();
-      expect(c).toBe(0n);
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] increments the counter from another account`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[2];
-      redeployCounter(account, {version: version.invoke});
-      const transferCall: Call = counter.populate("increment", {});
-      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
-      const receipt = await account.waitForTransaction(transaction_hash);
-      expect(receipt.isSuccess()).toBe(true);
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] reads the counter`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const c = await counter.get();
-      expect(c).toBeGreaterThan(0n);
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] resets the counter and fails`,
-    async () => {
-      const conf = config(env);
-      let account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const transferCall: Call = counter.populate("reset", {});
-      try {
-        account = testAccounts(conf)[2];
-        const { transaction_hash } = await account.execute(transferCall);
-        await account.waitForTransaction(transaction_hash);
-        expect(true).toBe(false);
-      } catch (e) {
-        expect(e).toBeDefined();
+describe.each(data)(
+  "counter contract (helper)",
+  ({ fees, version, accountID }) => {
+    let env: string;
+    let counter: Contract;
+    let altURL: string;
+    const redeployCounter = async (
+      account: Account,
+      details?: UniversalDetails
+    ) => {
+      if (!counter) {
+        counter = await deployCounter(account, account.address, details);
       }
-    },
-    default_timeout
-  );
+    };
 
-  it(
-    `[${fees}] reads the counter again`,
-    async () => {
+    beforeAll(() => {
+      env = "devnet";
       const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const c = await counter.get();
-      expect(c).toBeGreaterThan(0n);
-    },
-    default_timeout
-  );
+      // altURL = "http://localhost:8080";
+      if (!altURL) {
+        altURL = conf.providerURL;
+      }
+    });
 
-  it(
-    `[${fees}] increments the counter with an alt provider URL`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const provider = new RpcProvider({ nodeUrl: altURL });
-      const a = new Account(
-        provider,
-        conf.accounts[accountID].address,
-        conf.accounts[accountID].privateKey
-      );
-      const transferCall: Call = counter.populate("increment", {});
-      const { transaction_hash } = await account.execute(transferCall, {version: version.invoke});
-      const receipt = await a.waitForTransaction(transaction_hash);
-      expect(receipt.isSuccess()).toBe(true);
-    },
-    default_timeout
-  );
+    it(
+      `[${fees}] declare the Counter class`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        const c = await declareClass(account, classNames.Counter, {
+          version: version.declare,
+        });
+        expect(c.classHash).toEqual(classHash(classNames.Counter));
+      },
+      default_timeout
+    );
 
-  it(
-    `[${fees}] reads the counter from an alt. provider URL`,
-    async () => {
-      const conf = config(env);
-      const account = testAccounts(conf)[accountID];
-      redeployCounter(account, {version: version.invoke});
-      const provider = new RpcProvider({ nodeUrl: altURL });
-      const altCounter = new Contract(
-        CounterABI,
-        counter.address,
-        provider
-      ).typedv2(CounterABI);
-      const c = await altCounter.get();
-      expect(c).toBeGreaterThan(0n);
-    },
-    default_timeout
-  );
-});
+    it(
+      `[${fees}] deploys the Counter contract`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        const c = await deployCounter(account, account.address, {
+          version: version.invoke,
+        });
+        expect(c.address).toEqual(
+          await counterAddress(account.address, account.address)
+        );
+        counter = c;
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] increments the counter`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const transferCall: Call = counter.populate("increment", {});
+        const { transaction_hash } = await account.execute(transferCall, {
+          version: version.invoke,
+        });
+        const receipt = await account.waitForTransaction(transaction_hash);
+        expect(receipt.isSuccess()).toBe(true);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] reads the counter`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const c = await counter.get();
+        expect(c).toBeGreaterThan(0n);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] increments the counter by 5 and 6`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const transferCall: Call = counter.populate("increment_by_array", {
+          args: [5, 6],
+        });
+        const { transaction_hash } = await account.execute(transferCall, {
+          version: version.invoke,
+        });
+        const receipt = await account.waitForTransaction(transaction_hash);
+        expect(receipt.isSuccess()).toBe(true);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] reads the counter again`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const c = await counter.get();
+        expect(c).toBeGreaterThan(11n);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] resets the counter`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const transferCall: Call = counter.populate("reset", {});
+        const { transaction_hash } = await account.execute(transferCall, {
+          version: version.invoke,
+        });
+        const receipt = await account.waitForTransaction(transaction_hash);
+        expect(receipt.isSuccess()).toBe(true);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] reads the counter again`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const c = await counter.get();
+        expect(c).toBe(0n);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] increments the counter from another account`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[2];
+        redeployCounter(account, { version: version.invoke });
+        const transferCall: Call = counter.populate("increment", {});
+        const { transaction_hash } = await account.execute(transferCall, {
+          version: version.invoke,
+        });
+        const receipt = await account.waitForTransaction(transaction_hash);
+        expect(receipt.isSuccess()).toBe(true);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] reads the counter`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const c = await counter.get();
+        expect(c).toBeGreaterThan(0n);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] resets the counter and fails`,
+      async () => {
+        const conf = config(env);
+        let account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const transferCall: Call = counter.populate("reset", {});
+        try {
+          account = testAccounts(conf)[2];
+          const { transaction_hash } = await account.execute(transferCall);
+          await account.waitForTransaction(transaction_hash);
+          expect(true).toBe(false);
+        } catch (e) {
+          expect(e).toBeDefined();
+        }
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] reads the counter again`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const c = await counter.get();
+        expect(c).toBeGreaterThan(0n);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] increments the counter with an alt provider URL`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const provider = new RpcProvider({ nodeUrl: altURL });
+        const a = new Account(
+          provider,
+          conf.accounts[accountID].address,
+          conf.accounts[accountID].privateKey
+        );
+        const transferCall: Call = counter.populate("increment", {});
+        const { transaction_hash } = await account.execute(transferCall, {
+          version: version.invoke,
+        });
+        const receipt = await a.waitForTransaction(transaction_hash);
+        expect(receipt.isSuccess()).toBe(true);
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] reads the counter from an alt. provider URL`,
+      async () => {
+        const conf = config(env);
+        const account = testAccounts(conf)[accountID];
+        redeployCounter(account, { version: version.invoke });
+        const provider = new RpcProvider({ nodeUrl: altURL });
+        const altCounter = new Contract(
+          CounterABI,
+          counter.address,
+          provider
+        ).typedv2(CounterABI);
+        const c = await altCounter.get();
+        expect(c).toBeGreaterThan(0n);
+      },
+      default_timeout
+    );
+  }
+);

--- a/sdks/__tests__/helpers/src/counter.ts
+++ b/sdks/__tests__/helpers/src/counter.ts
@@ -1,6 +1,7 @@
 import { Contract, Call, Account, CallData, UniversalDetails } from "starknet";
 import { ABI as CounterABI } from "./abi/Counter";
 import { contractAddress, deployContract } from "./contract";
+import { classNames } from "./class";
 
 /**
  * Retrieves the address of the Counter contract.
@@ -16,7 +17,7 @@ export const counterAddress = async (
   const _calldata = myCallData.compile("constructor", {
     owner: ownerAddress,
   });
-  return contractAddress("Counter", deployerAddress, _calldata);
+  return contractAddress(classNames.Counter, deployerAddress, _calldata);
 };
 
 /**
@@ -28,13 +29,19 @@ export const counterAddress = async (
 export const deployCounter = async (
   deployerAccount: Account,
   ownerAddress: string,
-  details?: UniversalDetails,
+  details?: UniversalDetails
 ): Promise<Contract> => {
   const myCallData = new CallData(CounterABI);
   const _calldata = myCallData.compile("constructor", {
     owner: ownerAddress,
   });
-  return deployContract("Counter", CounterABI, deployerAccount, _calldata, details);
+  return deployContract(
+    classNames.Counter,
+    CounterABI,
+    deployerAccount,
+    _calldata,
+    details
+  );
 };
 
 export { CounterABI };

--- a/sdks/__tests__/helpers/src/natives.test.ts
+++ b/sdks/__tests__/helpers/src/natives.test.ts
@@ -5,7 +5,6 @@ import { RpcProvider, uint256 } from "starknet";
 
 import { data } from "./data.fixture";
 
-
 describe.each(data)("native tokens management", ({ fees, accountID }) => {
   let env = "devnet";
 
@@ -43,7 +42,7 @@ describe.each(data)("native tokens management", ({ fees, accountID }) => {
     async () => {
       const conf = config(env);
       const accounts = testAccounts(conf);
-      const TOKEN = (fees === "WEI" ? ETH : STRK)
+      const TOKEN = fees === "WEI" ? ETH : STRK;
       const eth = TOKEN(accounts[accountID]);
       const destAddress = accounts[2].address;
       const initialAmount = (await eth.balance_of(destAddress)) as bigint;

--- a/sdks/__tests__/helpers/src/simple_account.test.ts
+++ b/sdks/__tests__/helpers/src/simple_account.test.ts
@@ -1,45 +1,52 @@
-import { declareClass, classHash } from "./class";
+import { declareClass, classHash, classNames } from "./class";
 import { deploySimpleAccount, simpleAccountAddress } from "./simple_account";
 import { config, testAccounts } from "./utils";
 import { Account, RpcProvider } from "starknet";
 import { default_timeout } from "./parameters";
 import { data } from "./data.fixture";
 
-describe.each(data)("simple account management", ({ fees, version, accountID }) => {
-  let env: string;
-  let simpleAccount: Account;
-  beforeAll(() => {
-    env = "devnet";
-    const conf = config(env);
-    simpleAccount = new Account(
-      new RpcProvider({ nodeUrl: conf.providerURL }),
-      simpleAccountAddress(conf.accounts[0].publicKey, "0x10"),
-      conf.accounts[0].privateKey
-    );
-  });
-
-  it(
-    `[${fees}] deploys the Account class`,
-    async () => {
+describe.each(data)(
+  "simple account management",
+  ({ fees, version, accountID }) => {
+    let env: string;
+    let simpleAccount: Account;
+    beforeAll(() => {
+      env = "devnet";
       const conf = config(env);
-      const a = testAccounts(conf)[accountID];
-      const c = await declareClass(a, "SimpleAccount", { version: version.declare });
-      expect(c.classHash).toEqual(classHash("SimpleAccount"));
-    },
-    default_timeout
-  );
-
-  it(
-    `[${fees}] deploys the account contract`,
-    async () => {
-      const conf = config(env);
-      const a = testAccounts(conf)[accountID];
-      const publicKey = conf.accounts[accountID].publicKey;
-      const c = await deploySimpleAccount(a, publicKey, "0x10", { version: version.invoke });
-      expect(c).toEqual(
-        simpleAccountAddress(conf.accounts[accountID].publicKey, "0x10")
+      simpleAccount = new Account(
+        new RpcProvider({ nodeUrl: conf.providerURL }),
+        simpleAccountAddress(conf.accounts[0].publicKey, "0x10"),
+        conf.accounts[0].privateKey
       );
-    },
-    default_timeout
-  );
-});
+    });
+
+    it(
+      `[${fees}] deploys the Account class`,
+      async () => {
+        const conf = config(env);
+        const a = testAccounts(conf)[accountID];
+        const c = await declareClass(a, classNames.SimpleAccount, {
+          version: version.declare,
+        });
+        expect(c.classHash).toEqual(classHash(classNames.SimpleAccount));
+      },
+      default_timeout
+    );
+
+    it(
+      `[${fees}] deploys the account contract`,
+      async () => {
+        const conf = config(env);
+        const a = testAccounts(conf)[accountID];
+        const publicKey = conf.accounts[accountID].publicKey;
+        const c = await deploySimpleAccount(a, publicKey, "0x10", {
+          version: version.invoke,
+        });
+        expect(c).toEqual(
+          simpleAccountAddress(conf.accounts[accountID].publicKey, "0x10")
+        );
+      },
+      default_timeout
+    );
+  }
+);

--- a/sdks/__tests__/helpers/src/simple_account.ts
+++ b/sdks/__tests__/helpers/src/simple_account.ts
@@ -1,6 +1,7 @@
 import { Account, CallData, type UniversalDetails } from "starknet";
 import { ABI as SimpleAccountABI } from "./abi/SimpleAccount";
 import { accountAddress, deployAccount } from "./contract";
+import { classNames } from "./class";
 export { SimpleAccountABI };
 
 /**
@@ -18,7 +19,7 @@ export const simpleAccountAddress = (
     public_key: publicKey,
     more: more,
   });
-  return accountAddress("SimpleAccount", publicKey, calldata);
+  return accountAddress(classNames.SimpleAccount, publicKey, calldata);
 };
 
 /**
@@ -41,7 +42,7 @@ export const deploySimpleAccount = async (
   });
   return await deployAccount(
     deployerAccount,
-    "SimpleAccount",
+    classNames.SimpleAccount,
     publicKey,
     callData,
     details

--- a/sdks/__tests__/helpers/src/swap_router.test.ts
+++ b/sdks/__tests__/helpers/src/swap_router.test.ts
@@ -1,4 +1,4 @@
-import { classHash, declareClass } from "./class";
+import { classHash, declareClass, classNames } from "./class";
 import { config, testAccounts } from "./utils";
 import { udcAddress } from "./natives";
 import {
@@ -34,8 +34,10 @@ describe.each(data)("swap router", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareClass(a, "SwapRouter", { version: version.declare });
-      expect(c.classHash).toEqual(classHash("SwapRouter"));
+      const c = await declareClass(a, classNames.SwapRouter, {
+        version: version.declare,
+      });
+      expect(c.classHash).toEqual(classHash(classNames.SwapRouter));
     },
     default_timeout
   );
@@ -45,7 +47,9 @@ describe.each(data)("swap router", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await deploySwapRouter(a, a.address, { version: version.invoke });
+      const c = await deploySwapRouter(a, a.address, {
+        version: version.invoke,
+      });
       const routerAddress = await swapRouterAddress(a.address, a.address);
       swapRouterContract = new SwapRouter(routerAddress, a);
       expect(c.address).toEqual(routerAddress);
@@ -58,8 +62,10 @@ describe.each(data)("swap router", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareClass(a, "TokenA", { version: version.declare });
-      expect(c.classHash).toEqual(classHash("TokenA"));
+      const c = await declareClass(a, classNames.TokenA, {
+        version: version.declare,
+      });
+      expect(c.classHash).toEqual(classHash(classNames.TokenA));
     },
     default_timeout
   );
@@ -69,7 +75,9 @@ describe.each(data)("swap router", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await deployTokenA(a, swapRouterContract.address, a.address, { version: version.invoke });
+      const c = await deployTokenA(a, swapRouterContract.address, a.address, {
+        version: version.invoke,
+      });
       tokenA = new Contract(
         TokenAABI,
         await tokenAAddress(a.address, swapRouterContract.address, a.address),
@@ -87,8 +95,10 @@ describe.each(data)("swap router", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareClass(a, "TokenB", { version: version.declare });
-      expect(c.classHash).toEqual(classHash("TokenB"));
+      const c = await declareClass(a, classNames.TokenB, {
+        version: version.declare,
+      });
+      expect(c.classHash).toEqual(classHash(classNames.TokenB));
     },
     default_timeout
   );
@@ -98,7 +108,9 @@ describe.each(data)("swap router", ({ fees, version, accountID }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await deployTokenB(a, swapRouterContract.address, a.address, { version: version.invoke });
+      const c = await deployTokenB(a, swapRouterContract.address, a.address, {
+        version: version.invoke,
+      });
       tokenB = new Contract(
         TokenBABI,
         await tokenBAddress(a.address, swapRouterContract.address, a.address),
@@ -111,15 +123,14 @@ describe.each(data)("swap router", ({ fees, version, accountID }) => {
     default_timeout
   );
 
-  it(
-    `[${fees}] compute and check TokenA address`, async () => {
+  it(`[${fees}] compute and check TokenA address`, async () => {
     const conf = config(env);
     const a = testAccounts(conf)[accountID];
     const creatorAddress = a.address;
     const recipientAddress = swapRouterContract.address;
     const ownerAddress = a.address;
     const factoryAddress = udcAddress;
-    const h = classHash("TokenA");
+    const h = classHash(classNames.TokenA);
     // This test just shows how to use calculateContractAddressFromHash for new devs
     // see https://community.starknet.io/t/universal-deployer-contract-proposal/1864
     // to understand the calculateContractAddressFromHash function works

--- a/sdks/__tests__/helpers/src/swap_router.ts
+++ b/sdks/__tests__/helpers/src/swap_router.ts
@@ -3,6 +3,7 @@ import { ABI as SwapRouterABI } from "./abi/SwapRouter";
 import { contractAddress, deployContract } from "./contract";
 import type { Uint256, UniversalDetails } from "starknet";
 import { ABI as TokenAABI } from "./abi/TokenA";
+import { classNames } from "./class";
 
 /**
  * Retrieves the swap router address from its deployer and owner.
@@ -18,7 +19,11 @@ export const swapRouterAddress = async (
   const _calldata = myCallData.compile("constructor", {
     owner: ownerAddress,
   });
-  return await contractAddress("SwapRouter", deployerAddress, _calldata);
+  return await contractAddress(
+    classNames.SwapRouter,
+    deployerAddress,
+    _calldata
+  );
 };
 
 /**
@@ -37,7 +42,7 @@ export const deploySwapRouter = async (
     owner: ownerAddress,
   });
   return deployContract(
-    "SwapRouter",
+    classNames.SwapRouter,
     SwapRouterABI,
     deployerAccount,
     _calldata,

--- a/sdks/__tests__/helpers/src/tokens.ts
+++ b/sdks/__tests__/helpers/src/tokens.ts
@@ -4,6 +4,7 @@ import { ABI as TokenAABI } from "./abi/TokenA";
 import { ABI as TokenBABI } from "./abi/TokenB";
 
 import { contractAddress } from "./contract";
+import { classNames } from "./class";
 
 /**
  * Retrieves the token A address.
@@ -18,7 +19,10 @@ export const tokenAAddress = async (
   recipientAddress: string,
   ownerAddress: string
 ) =>
-  contractAddress("TokenA", deployerAddress, [recipientAddress, ownerAddress]);
+  contractAddress(classNames.TokenA, deployerAddress, [
+    recipientAddress,
+    ownerAddress,
+  ]);
 
 /**
  * Deploys the TokenA contract.
@@ -37,7 +41,13 @@ export const deployTokenA = async (
     recipient: recipientAddress,
     owner: ownerAddress,
   });
-  return deployContract("TokenA", TokenAABI, deployerAccount, _calldata, details);
+  return deployContract(
+    classNames.TokenA,
+    TokenAABI,
+    deployerAccount,
+    _calldata,
+    details
+  );
 };
 
 /**
@@ -53,7 +63,10 @@ export const tokenBAddress = async (
   recipientAddress: string,
   ownerAddress: string
 ) =>
-  contractAddress("TokenB", deployerAddress, [recipientAddress, ownerAddress]);
+  contractAddress(classNames.TokenB, deployerAddress, [
+    recipientAddress,
+    ownerAddress,
+  ]);
 
 /**
  * Deploys the TokenB contract.
@@ -72,5 +85,11 @@ export const deployTokenB = async (
     recipient: recipientAddress,
     owner: ownerAddress,
   });
-  return deployContract("TokenB", TokenBABI, deployerAccount, _calldata, details);
+  return deployContract(
+    classNames.TokenB,
+    TokenBABI,
+    deployerAccount,
+    _calldata,
+    details
+  );
 };

--- a/sdks/__tests__/module-guarded/package.json
+++ b/sdks/__tests__/module-guarded/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module-guarded",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "scripts": {
     "test": "jest --runInBand --verbose"
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/sdks/__tests__/module-guarded/src/security.test.ts
+++ b/sdks/__tests__/module-guarded/src/security.test.ts
@@ -13,12 +13,14 @@ import {
   SmartrAccount,
   deployAccount,
   accountAddress,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, CallData, Signer } from "starknet";
 import {
   declareClass as declareModuleClass,
   classHash as moduleClassHash,
   GuardedValidatorABI,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { data } from "./data.fixture";
 
@@ -52,10 +54,16 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareModuleClass(a, "GuardedValidator", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(moduleClassHash("GuardedValidator"));
+        const c = await declareModuleClass(
+          a,
+          moduleClassNames.GuardedValidator,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          moduleClassHash(moduleClassNames.GuardedValidator)
+        );
       },
       default_timeout
     );
@@ -65,10 +73,16 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.SmartrAccount,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.SmartrAccount)
+        );
       },
       default_timeout
     );
@@ -81,14 +95,16 @@ describe.each(data)(
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const publicKey = conf.accounts[accountID].publicKey;
         const privateKey = conf.accounts[accountID].privateKey;
-        const moduleValidatorClassHash = moduleClassHash("GuardedValidator");
+        const moduleValidatorClassHash = moduleClassHash(
+          moduleClassNames.GuardedValidator
+        );
         const calldata = [
           moduleValidatorClassHash,
           "0x1",
           smartAccountPublicKey,
         ];
         const address = accountAddress(
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           smartAccountPublicKey,
           calldata
         );
@@ -134,7 +150,9 @@ describe.each(data)(
       `[${fees}][guarded]: deploys a SmartrAccount account`,
       async () => {
         const conf = config(env);
-        const moduleValidatorClassHash = moduleClassHash("GuardedValidator");
+        const moduleValidatorClassHash = moduleClassHash(
+          moduleClassNames.GuardedValidator
+        );
         const calldata = [
           moduleValidatorClassHash,
           "0x1",
@@ -142,13 +160,17 @@ describe.each(data)(
         ];
         const address = await deployAccount(
           smartrAccount,
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           smartAccountPublicKey,
           calldata,
           { version: version.deploy_account }
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", smartAccountPublicKey, calldata)
+          accountAddress(
+            accountClassNames.SmartrAccount,
+            smartAccountPublicKey,
+            calldata
+          )
         );
       },
       default_timeout
@@ -161,7 +183,7 @@ describe.each(data)(
         const calldata = new CallData(GuardedValidatorABI);
         const nestedCalldata = calldata.compile("get_owner_key", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("GuardedValidator"),
+          moduleClassHash(moduleClassNames.GuardedValidator),
           "get_owner_key",
           nestedCalldata
         );

--- a/sdks/__tests__/module-guarded/src/transaction.test.ts
+++ b/sdks/__tests__/module-guarded/src/transaction.test.ts
@@ -11,6 +11,7 @@ import {
   initial_EthTransfer,
   STRK,
   initial_StrkTransfer,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -18,12 +19,14 @@ import {
   SmartrAccount,
   deployAccount,
   accountAddress,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, CallData, cairo, Signer } from "starknet";
 import {
   declareClass as declareModuleClass,
   classHash as moduleClassHash,
   GuardedValidatorABI,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { data } from "./data.fixture";
 
@@ -58,8 +61,8 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const account = testAccounts(conf)[accountID];
-        const c = await declareHelperClass(account, "Counter");
-        expect(c.classHash).toEqual(helperClassHash("Counter"));
+        const c = await declareHelperClass(account, helperClassNames.Counter);
+        expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
       },
       default_timeout
     );
@@ -83,8 +86,13 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareModuleClass(a, "GuardedValidator");
-        expect(c.classHash).toEqual(moduleClassHash("GuardedValidator"));
+        const c = await declareModuleClass(
+          a,
+          moduleClassNames.GuardedValidator
+        );
+        expect(c.classHash).toEqual(
+          moduleClassHash(moduleClassNames.GuardedValidator)
+        );
       },
       default_timeout
     );
@@ -94,8 +102,10 @@ describe.each(data)(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount");
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        const c = await declareAccountClass(a, accountClassNames.SmartrAccount);
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.SmartrAccount)
+        );
       },
       default_timeout
     );
@@ -107,14 +117,16 @@ describe.each(data)(
         const sender = testAccounts(conf)[accountID];
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const privateKey = conf.accounts[accountID].privateKey;
-        const moduleValidatorClassHash = moduleClassHash("GuardedValidator");
+        const moduleValidatorClassHash = moduleClassHash(
+          moduleClassNames.GuardedValidator
+        );
         const calldata = [
           moduleValidatorClassHash,
           "0x1",
           smartAccountPublicKey,
         ];
         const address = accountAddress(
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           smartAccountPublicKey,
           calldata
         );
@@ -157,7 +169,9 @@ describe.each(data)(
       `[${fees}][guarded]: deploys a SmartrAccount account`,
       async () => {
         const conf = config(env);
-        const moduleValidatorClassHash = moduleClassHash("GuardedValidator");
+        const moduleValidatorClassHash = moduleClassHash(
+          moduleClassNames.GuardedValidator
+        );
         const calldata = [
           moduleValidatorClassHash,
           "0x1",
@@ -165,12 +179,16 @@ describe.each(data)(
         ];
         const address = await deployAccount(
           smartrAccount,
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           smartAccountPublicKey,
           calldata
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", smartAccountPublicKey, calldata)
+          accountAddress(
+            accountClassNames.SmartrAccount,
+            smartAccountPublicKey,
+            calldata
+          )
         );
       },
       default_timeout
@@ -183,7 +201,7 @@ describe.each(data)(
         const calldata = new CallData(GuardedValidatorABI);
         const nestedCalldata = calldata.compile("get_owner_key", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("GuardedValidator"),
+          moduleClassHash(moduleClassNames.GuardedValidator),
           "get_owner_key",
           nestedCalldata
         );
@@ -249,7 +267,7 @@ describe.each(data)(
           throw new Error("SmartrAccount is not deployed");
         }
         const output = await smartrAccount.isModule(
-          moduleClassHash("GuardedValidator")
+          moduleClassHash(moduleClassNames.GuardedValidator)
         );
         expect(output).toBe(true);
       },
@@ -278,8 +296,8 @@ describe.each(data)(
           throw new Error("SmartrAccount is not deployed");
         }
         try {
-          await await smartrAccount.removeModule(
-            moduleClassHash("GuardedValidator")
+          await smartrAccount.removeModule(
+            moduleClassHash(moduleClassNames.GuardedValidator)
           );
           expect(true).toBe(false);
         } catch (e) {
@@ -296,7 +314,7 @@ describe.each(data)(
           throw new Error("SmartrAccount is not deployed");
         }
         const output = await smartrAccount.isModule(
-          moduleClassHash("GuardedValidator")
+          moduleClassHash(moduleClassNames.GuardedValidator)
         );
         expect(output).toBe(true);
       },

--- a/sdks/__tests__/module-sessionkey/package.json
+++ b/sdks/__tests__/module-sessionkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module-sessionkey",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "scripts": {
     "test": "jest --runInBand --verbose"
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/sdks/__tests__/module-sessionkey/src/sessionkey_with_root.test.ts
+++ b/sdks/__tests__/module-sessionkey/src/sessionkey_with_root.test.ts
@@ -11,6 +11,7 @@ import {
   initial_StrkTransfer,
   ETH,
   STRK,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import { PolicyManager } from "@0xknwn/starknet-module-sessionkey";
 import {
@@ -21,6 +22,7 @@ import {
   accountAddress,
   hash_auth_message,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, CallData } from "starknet";
 import {
@@ -61,10 +63,10 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const account = testAccounts(conf)[accountID];
-        const c = await declareHelperClass(account, "Counter", {
+        const c = await declareHelperClass(account, helperClassNames.Counter, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(helperClassHash("Counter"));
+        expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
       },
       default_timeout
     );
@@ -90,10 +92,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "StarkValidator", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("StarkValidator"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.StarkValidator,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.StarkValidator)
+        );
       },
       default_timeout
     );
@@ -103,10 +111,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.SmartrAccount,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.SmartrAccount)
+        );
       },
       default_timeout
     );
@@ -119,12 +133,18 @@ describe.each([data[1]])(
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const publicKey = conf.accounts[accountID].publicKey;
         const privateKey = conf.accounts[accountID].privateKey;
-        const starkValidatorClassHash = accountClassHash("StarkValidator");
+        const starkValidatorClassHash = accountClassHash(
+          accountClassNames.StarkValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
-        const address = accountAddress("SmartrAccount", publicKey, calldata);
+        const address = accountAddress(
+          accountClassNames.SmartrAccount,
+          publicKey,
+          calldata
+        );
         const TOKEN = fees === "WEI" ? ETH : STRK;
         const initial_transfer =
           fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -151,20 +171,22 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const publicKey = conf.accounts[accountID].publicKey;
-        const starkValidatorClassHash = accountClassHash("StarkValidator");
+        const starkValidatorClassHash = accountClassHash(
+          accountClassNames.StarkValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
         const address = await deployAccount(
           smartrAccount,
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           publicKey,
           calldata,
           { version: version.deploy_account }
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", publicKey, calldata)
+          accountAddress(accountClassNames.SmartrAccount, publicKey, calldata)
         );
       },
       default_timeout
@@ -177,7 +199,7 @@ describe.each([data[1]])(
         const calldata = new CallData(StarkValidatorABI);
         const data = calldata.compile("get_public_key", {});
         const c = await smartrAccount.callOnModule(
-          accountClassHash("StarkValidator"),
+          accountClassHash(accountClassNames.StarkValidator),
           "get_public_key",
           data
         );
@@ -322,13 +344,13 @@ describe.each([data[1]])(
         );
         const root = policyManager.getRoot();
         const r = await sessionKeyModule.request(
-          accountClassHash("StarkValidator")
+          accountClassHash(accountClassNames.StarkValidator)
         );
         expect(r.hash).toBe(
           hash_auth_message(
             smartrAccount.address,
             sessionkeyClassHash("SessionKeyValidator"),
-            accountClassHash("StarkValidator"),
+            accountClassHash(accountClassNames.StarkValidator),
             conf.accounts[1].publicKey,
             `0x${next_timestamp.toString(16)}`,
             root,
@@ -346,7 +368,7 @@ describe.each([data[1]])(
       }
       const conf = config(env);
       const grantor = new SessionKeyGrantor(
-        accountClassHash("StarkValidator"),
+        accountClassHash(accountClassNames.StarkValidator),
         conf.accounts[accountID].privateKey
       );
       const signature = await grantor.sign(sessionKeyModule);

--- a/sdks/__tests__/module-sessionkey/src/sessionkey_zero_root.test.ts
+++ b/sdks/__tests__/module-sessionkey/src/sessionkey_zero_root.test.ts
@@ -11,6 +11,7 @@ import {
   initial_StrkTransfer,
   ETH,
   STRK,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -20,6 +21,7 @@ import {
   accountAddress,
   hash_auth_message,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, CallData } from "starknet";
 import {
@@ -63,10 +65,10 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const account = testAccounts(conf)[accountID];
-        const c = await declareHelperClass(account, "Counter", {
+        const c = await declareHelperClass(account, helperClassNames.Counter, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(helperClassHash("Counter"));
+        expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
       },
       default_timeout
     );
@@ -92,10 +94,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "StarkValidator", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("StarkValidator"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.StarkValidator,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.StarkValidator)
+        );
       },
       default_timeout
     );
@@ -105,10 +113,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.SmartrAccount,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.SmartrAccount)
+        );
       },
       default_timeout
     );
@@ -121,12 +135,18 @@ describe.each([data[1]])(
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const publicKey = conf.accounts[accountID].publicKey;
         const privateKey = conf.accounts[accountID].privateKey;
-        const starkValidatorClassHash = accountClassHash("StarkValidator");
+        const starkValidatorClassHash = accountClassHash(
+          accountClassNames.StarkValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
-        const address = accountAddress("SmartrAccount", publicKey, calldata);
+        const address = accountAddress(
+          accountClassNames.SmartrAccount,
+          publicKey,
+          calldata
+        );
         const TOKEN = fees === "WEI" ? ETH : STRK;
         const initial_transfer =
           fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -153,20 +173,22 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const publicKey = conf.accounts[accountID].publicKey;
-        const starkValidatorClassHash = accountClassHash("StarkValidator");
+        const starkValidatorClassHash = accountClassHash(
+          accountClassNames.StarkValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
         const address = await deployAccount(
           smartrAccount,
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           publicKey,
           calldata,
           { version: version.deploy_account }
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", publicKey, calldata)
+          accountAddress(accountClassNames.SmartrAccount, publicKey, calldata)
         );
       },
       default_timeout
@@ -179,7 +201,7 @@ describe.each([data[1]])(
         const calldata = new CallData(StarkValidatorABI);
         const data = calldata.compile("get_public_key", {});
         const c = await smartrAccount.callOnModule(
-          accountClassHash("StarkValidator"),
+          accountClassHash(accountClassNames.StarkValidator),
           "get_public_key",
           data
         );
@@ -317,13 +339,13 @@ describe.each([data[1]])(
           `0x${next_timestamp.toString(16)}`
         );
         const r = await sessionKeyModule.request(
-          accountClassHash("StarkValidator")
+          accountClassHash(accountClassNames.StarkValidator)
         );
         expect(r.hash).toBe(
           hash_auth_message(
             smartrAccount.address,
             sessionkeyClassHash("SessionKeyValidator"),
-            accountClassHash("StarkValidator"),
+            accountClassHash(accountClassNames.StarkValidator),
             conf.accounts[1].publicKey,
             `0x${next_timestamp.toString(16)}`,
             "0x0",
@@ -341,7 +363,7 @@ describe.each([data[1]])(
       }
       const conf = config(env);
       const grantor = new SessionKeyGrantor(
-        accountClassHash("StarkValidator"),
+        accountClassHash(accountClassNames.StarkValidator),
         conf.accounts[accountID].privateKey
       );
       const signature = await grantor.sign(sessionKeyModule);

--- a/sdks/__tests__/module-sessionkey/src/swap.test.ts
+++ b/sdks/__tests__/module-sessionkey/src/swap.test.ts
@@ -15,6 +15,7 @@ import {
   initial_StrkTransfer,
   ETH,
   STRK,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -24,6 +25,7 @@ import {
   accountAddress,
   hash_auth_message,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { cairo, RpcProvider, CallData, Contract } from "starknet";
 import {
@@ -70,10 +72,10 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareHelperClass(a, "SwapRouter", {
+      const c = await declareHelperClass(a, helperClassNames.SwapRouter, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(helperClassHash("SwapRouter"));
+      expect(c.classHash).toEqual(helperClassHash(helperClassNames.SwapRouter));
     },
     default_timeout
   );
@@ -98,10 +100,10 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareHelperClass(a, "TokenA", {
+      const c = await declareHelperClass(a, helperClassNames.TokenA, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(helperClassHash("TokenA"));
+      expect(c.classHash).toEqual(helperClassHash(helperClassNames.TokenA));
     },
     default_timeout
   );
@@ -127,10 +129,10 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareHelperClass(a, "TokenB", {
+      const c = await declareHelperClass(a, helperClassNames.TokenB, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(helperClassHash("TokenB"));
+      expect(c.classHash).toEqual(helperClassHash(helperClassNames.TokenB));
     },
     default_timeout
   );
@@ -188,10 +190,12 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "StarkValidator", {
+      const c = await declareAccountClass(a, accountClassNames.StarkValidator, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(accountClassHash("StarkValidator"));
+      expect(c.classHash).toEqual(
+        accountClassHash(accountClassNames.StarkValidator)
+      );
     },
     default_timeout
   );
@@ -201,10 +205,12 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareAccountClass(a, "SmartrAccount", {
+      const c = await declareAccountClass(a, accountClassNames.SmartrAccount, {
         version: version.declare,
       });
-      expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+      expect(c.classHash).toEqual(
+        accountClassHash(accountClassNames.SmartrAccount)
+      );
     },
     default_timeout
   );
@@ -217,12 +223,18 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
       const p = new RpcProvider({ nodeUrl: conf.providerURL });
       const publicKey = conf.accounts[accountID].publicKey;
       const privateKey = conf.accounts[accountID].privateKey;
-      const starkValidatorClassHash = accountClassHash("StarkValidator");
+      const starkValidatorClassHash = accountClassHash(
+        accountClassNames.StarkValidator
+      );
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
       });
-      const address = accountAddress("SmartrAccount", publicKey, calldata);
+      const address = accountAddress(
+        accountClassNames.SmartrAccount,
+        publicKey,
+        calldata
+      );
       const TOKEN = fees === "WEI" ? ETH : STRK;
       const initial_transfer =
         fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -249,20 +261,22 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
     async () => {
       const conf = config(env);
       const publicKey = conf.accounts[accountID].publicKey;
-      const starkValidatorClassHash = accountClassHash("StarkValidator");
+      const starkValidatorClassHash = accountClassHash(
+        accountClassNames.StarkValidator
+      );
       const calldata = new CallData(SmartrAccountABI).compile("constructor", {
         core_validator: starkValidatorClassHash,
         args: [publicKey],
       });
       const address = await deployAccount(
         smartrAccount,
-        "SmartrAccount",
+        accountClassNames.SmartrAccount,
         publicKey,
         calldata,
         { version: version.deploy_account }
       );
       expect(address).toEqual(
-        accountAddress("SmartrAccount", publicKey, calldata)
+        accountAddress(accountClassNames.SmartrAccount, publicKey, calldata)
       );
     },
     default_timeout
@@ -275,7 +289,7 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
       const calldata = new CallData(StarkValidatorABI);
       const data = calldata.compile("get_public_key", {});
       const c = await smartrAccount.callOnModule(
-        accountClassHash("StarkValidator"),
+        accountClassHash(accountClassNames.StarkValidator),
         "get_public_key",
         data
       );
@@ -349,13 +363,13 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
         `0x${next_timestamp.toString(16)}`
       );
       const r = await sessionKeyModule.request(
-        accountClassHash("StarkValidator")
+        accountClassHash(accountClassNames.StarkValidator)
       );
       expect(r.hash).toBe(
         hash_auth_message(
           smartrAccount.address,
           sessionkeyClassHash("SessionKeyValidator"),
-          accountClassHash("StarkValidator"),
+          accountClassHash(accountClassNames.StarkValidator),
           conf.accounts[1].publicKey,
           `0x${next_timestamp.toString(16)}`,
           "0x0",
@@ -373,7 +387,7 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
     }
     const conf = config(env);
     const grantor = new SessionKeyGrantor(
-      accountClassHash("StarkValidator"),
+      accountClassHash(accountClassNames.StarkValidator),
       conf.accounts[accountID].privateKey
     );
     const signature = await grantor.sign(sessionKeyModule);

--- a/sdks/__tests__/module/package.json
+++ b/sdks/__tests__/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "scripts": {
     "test": "jest --runInBand --verbose"
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/sdks/__tests__/module/src/core.test.ts
+++ b/sdks/__tests__/module/src/core.test.ts
@@ -11,6 +11,7 @@ import {
   STRK,
   initial_EthTransfer,
   initial_StrkTransfer,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -18,6 +19,7 @@ import {
   SmartrAccount,
   deployAccount,
   accountAddress,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import {
   RpcProvider,
@@ -27,6 +29,8 @@ import {
   hash,
   cairo,
   UniversalDetails,
+  Account,
+  BigNumberish,
 } from "starknet";
 import {
   declareClass as declareModuleClass,
@@ -34,8 +38,37 @@ import {
   EthValidatorABI,
   P256ValidatorABI,
   P256Signer,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { V1, V2, V3 } from "./data.fixture";
+
+const declareClass = async (
+  a: Account,
+  className: moduleClassNames | accountClassNames.StarkValidator,
+  version: BigNumberish | undefined
+) => {
+  if (className === accountClassNames.StarkValidator) {
+    const c = await declareAccountClass(a, className, {
+      version,
+    });
+    return c;
+  }
+  const c = await declareModuleClass(a, className, {
+    version,
+  });
+  return c;
+};
+
+const classHash = (
+  className: moduleClassNames | accountClassNames.StarkValidator
+) => {
+  if (className === accountClassNames.StarkValidator) {
+    const c = accountClassHash(className);
+    return c;
+  }
+  const c = moduleClassHash(className);
+  return c;
+};
 
 const dataset = [
   {
@@ -52,7 +85,9 @@ const dataset = [
       publicKeyArray: [
         "0x636891ed7d6a8a4bf0c6c96cf3a1562b03d6fb63909691f9504f2f2b67d43be",
       ],
-      className: "StarkValidator" as "StarkValidator",
+      className: accountClassNames.StarkValidator as
+        | moduleClassNames
+        | accountClassNames.StarkValidator,
       signer: Signer,
       validatorABI: EthValidatorABI,
     },
@@ -71,7 +106,9 @@ const dataset = [
       publicKeyArray: [
         "0x636891ed7d6a8a4bf0c6c96cf3a1562b03d6fb63909691f9504f2f2b67d43be",
       ],
-      className: "StarkValidator" as "StarkValidator",
+      className: accountClassNames.StarkValidator as
+        | moduleClassNames
+        | accountClassNames.StarkValidator,
       signer: Signer,
       validatorABI: EthValidatorABI,
     },
@@ -94,7 +131,9 @@ const dataset = [
         "258172356515136873455592221375042794236",
         "69849287226094710129367771214955413606",
       ],
-      className: "EthValidator" as "EthValidator",
+      className: moduleClassNames.EthValidator as
+        | moduleClassNames
+        | accountClassNames.StarkValidator,
       signer: EthSigner,
       validatorABI: EthValidatorABI,
     },
@@ -117,7 +156,9 @@ const dataset = [
         "258172356515136873455592221375042794236",
         "69849287226094710129367771214955413606",
       ],
-      className: "EthValidator" as "EthValidator",
+      className: moduleClassNames.EthValidator as
+        | moduleClassNames
+        | accountClassNames.StarkValidator,
       signer: EthSigner,
       validatorABI: EthValidatorABI,
     },
@@ -142,7 +183,9 @@ const dataset = [
         "230988565823064299531546210785320445498",
         "202889101106158949967186230758848275236",
       ],
-      className: "P256Validator" as "P256Validator",
+      className: moduleClassNames.P256Validator as
+        | moduleClassNames
+        | accountClassNames.StarkValidator,
       signer: P256Signer,
       validatorABI: P256ValidatorABI,
     },
@@ -167,7 +210,9 @@ const dataset = [
         "230988565823064299531546210785320445498",
         "202889101106158949967186230758848275236",
       ],
-      className: "P256Validator" as "P256Validator",
+      className: moduleClassNames.P256Validator as
+        | moduleClassNames
+        | accountClassNames.StarkValidator,
       signer: P256Signer,
       validatorABI: P256ValidatorABI,
     },
@@ -200,10 +245,10 @@ describe.each([dataset[3], dataset[5]])(
       async () => {
         const conf = config(env);
         const account = testAccounts(conf)[accountID];
-        const c = await declareHelperClass(account, "Counter", {
+        const c = await declareHelperClass(account, helperClassNames.Counter, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(helperClassHash("Counter"));
+        expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
       },
       default_timeout
     );
@@ -229,10 +274,8 @@ describe.each([dataset[3], dataset[5]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareModuleClass(a, data.className, {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(moduleClassHash(data.className));
+        const c = await declareClass(a, data.className, version.declare);
+        expect(c.classHash).toEqual(classHash(data.className));
       },
       default_timeout
     );
@@ -242,10 +285,16 @@ describe.each([dataset[3], dataset[5]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.SmartrAccount,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.SmartrAccount)
+        );
       },
       default_timeout
     );
@@ -256,14 +305,18 @@ describe.each([dataset[3], dataset[5]])(
         const conf = config(env);
         const sender = testAccounts(conf)[accountID];
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
-        const moduleValidatorClassHash = moduleClassHash(data.className);
+        const moduleValidatorClassHash = classHash(data.className);
         const calldata = [
           moduleValidatorClassHash,
           data.publicKeyArray.length.toString(10),
           ...data.publicKeyArray,
         ];
         const salt = hash.computeHashOnElements(data.publicKeyArray);
-        const address = accountAddress("SmartrAccount", salt, calldata);
+        const address = accountAddress(
+          accountClassNames.SmartrAccount,
+          salt,
+          calldata
+        );
         const TOKEN = fees === "WEI" ? ETH : STRK;
         const initial_transfer =
           fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -289,14 +342,18 @@ describe.each([dataset[3], dataset[5]])(
     it(
       `[${fees}][${name}]: checks ${fees === "WEI" ? "$ETH" : "$STRK"} to the account address`,
       async () => {
-        const moduleValidatorClassHash = moduleClassHash(data.className);
+        const validatorClassHash = classHash(data.className);
         const calldata = [
-          moduleValidatorClassHash,
+          validatorClassHash,
           data.publicKeyArray.length.toString(10),
           ...data.publicKeyArray,
         ];
         const salt = hash.computeHashOnElements(data.publicKeyArray);
-        const address = accountAddress("SmartrAccount", salt, calldata);
+        const address = accountAddress(
+          accountClassNames.SmartrAccount,
+          salt,
+          calldata
+        );
         const TOKEN = fees === "WEI" ? ETH : STRK;
         const value = await TOKEN(smartrAccountWithModule).balance_of(address);
         expect(cairo.uint256(value)).toEqual(
@@ -310,7 +367,7 @@ describe.each([dataset[3], dataset[5]])(
       `[${fees}][${name}]: deploys a SmartrAccount account`,
       async () => {
         const conf = config(env);
-        const moduleValidatorClassHash = moduleClassHash(data.className);
+        const moduleValidatorClassHash = classHash(data.className);
         const calldata = [
           moduleValidatorClassHash,
           data.publicKeyArray.length.toString(10),
@@ -334,7 +391,7 @@ describe.each([dataset[3], dataset[5]])(
         const salt = hash.computeHashOnElements(data.publicKeyArray);
         const address = await deployAccount(
           smartrAccountWithModule,
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           salt,
           calldata,
           {
@@ -343,7 +400,7 @@ describe.each([dataset[3], dataset[5]])(
           }
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", salt, calldata)
+          accountAddress(accountClassNames.SmartrAccount, salt, calldata)
         );
       },
       default_timeout
@@ -356,7 +413,7 @@ describe.each([dataset[3], dataset[5]])(
         const calldata = new CallData(data.validatorABI);
         const nestedCalldata = calldata.compile("get_public_key", {});
         const c = await smartrAccountWithModule.callOnModule(
-          moduleClassHash(data.className),
+          classHash(data.className),
           "get_public_key",
           nestedCalldata
         );

--- a/sdks/__tests__/module/src/multisig.test.ts
+++ b/sdks/__tests__/module/src/multisig.test.ts
@@ -12,6 +12,7 @@ import {
   initial_StrkTransfer,
   ETH,
   STRK,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -20,11 +21,13 @@ import {
   deployAccount,
   accountAddress,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import {
   declareClass as declareModuleClass,
   classHash as moduleClassHash,
   MultisigValidatorABI,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { Contract, RpcProvider, CallData } from "starknet";
 import { data } from "./data.fixture";
@@ -46,10 +49,10 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const account = testAccounts(conf)[accountID];
-        const c = await declareHelperClass(account, "Counter", {
+        const c = await declareHelperClass(account, helperClassNames.Counter, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(helperClassHash("Counter"));
+        expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
       },
       default_timeout
     );
@@ -75,10 +78,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareModuleClass(a, "MultisigValidator", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(moduleClassHash("MultisigValidator"));
+        const c = await declareModuleClass(
+          a,
+          moduleClassNames.MultisigValidator,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          moduleClassHash(moduleClassNames.MultisigValidator)
+        );
       },
       default_timeout
     );
@@ -88,10 +97,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.SmartrAccount,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.SmartrAccount)
+        );
       },
       default_timeout
     );
@@ -104,12 +119,18 @@ describe.each([data[1]])(
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const privateKey = conf.accounts[accountID].privateKey;
         const publicKey = conf.accounts[accountID].publicKey;
-        const moduleValidatorClassHash = moduleClassHash("MultisigValidator");
+        const moduleValidatorClassHash = moduleClassHash(
+          moduleClassNames.MultisigValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: moduleValidatorClassHash,
           args: [publicKey],
         });
-        const address = accountAddress("SmartrAccount", publicKey, calldata);
+        const address = accountAddress(
+          accountClassNames.SmartrAccount,
+          publicKey,
+          calldata
+        );
         const TOKEN = fees === "WEI" ? ETH : STRK;
         const initial_transfer =
           fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -136,20 +157,22 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const publicKey = conf.accounts[accountID].publicKey;
-        const moduleValidatorClassHash = moduleClassHash("MultisigValidator");
+        const moduleValidatorClassHash = moduleClassHash(
+          moduleClassNames.MultisigValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: moduleValidatorClassHash,
           args: [publicKey],
         });
         const address = await deployAccount(
           smartrAccount,
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           publicKey,
           calldata,
           { version: version.deploy_account }
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", publicKey, calldata)
+          accountAddress(accountClassNames.SmartrAccount, publicKey, calldata)
         );
       },
       default_timeout
@@ -162,7 +185,7 @@ describe.each([data[1]])(
         const calldata = new CallData(MultisigValidatorABI);
         const data = calldata.compile("get_public_keys", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "get_public_keys",
           data
         );
@@ -181,7 +204,7 @@ describe.each([data[1]])(
         const calldata = new CallData(MultisigValidatorABI);
         const data = calldata.compile("get_threshold", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "get_threshold",
           data
         );
@@ -269,7 +292,7 @@ describe.each([data[1]])(
         const calldata = new CallData(MultisigValidatorABI);
         const data = calldata.compile("get_threshold", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "get_threshold",
           data
         );
@@ -290,7 +313,7 @@ describe.each([data[1]])(
           new_public_key: conf.accounts[altAccountID].publicKey,
         });
         const { transaction_hash } = await smartrAccount.executeOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "add_public_key",
           data
         );
@@ -317,7 +340,7 @@ describe.each([data[1]])(
         const calldata = new CallData(MultisigValidatorABI);
         const data = calldata.compile("get_public_keys", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "get_public_keys",
           data
         );
@@ -404,7 +427,7 @@ describe.each([data[1]])(
           new_threshold: 2,
         });
         const { transaction_hash } = await smartrAccount.executeOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "set_threshold",
           data
         );
@@ -425,7 +448,7 @@ describe.each([data[1]])(
           new_public_key: conf.accounts[thirdAccountID].publicKey,
         });
         const transactions = await smartrAccount.executeOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "add_public_key",
           data,
           false
@@ -458,7 +481,7 @@ describe.each([data[1]])(
         const calldata = new CallData(MultisigValidatorABI);
         const data = calldata.compile("get_public_keys", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "get_public_keys",
           data
         );
@@ -562,7 +585,7 @@ describe.each([data[1]])(
           new_threshold: 1,
         });
         const transactions = await smartrAccount.executeOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "set_threshold",
           data,
           false
@@ -594,7 +617,7 @@ describe.each([data[1]])(
         const calldata = new CallData(MultisigValidatorABI);
         const data = calldata.compile("get_threshold", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "get_threshold",
           data
         );
@@ -631,7 +654,7 @@ describe.each([data[1]])(
           old_public_key: conf.accounts[altAccountID].publicKey,
         });
         const { transaction_hash } = await smartrAccount.executeOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "remove_public_key",
           data
         );
@@ -648,7 +671,7 @@ describe.each([data[1]])(
         const calldata = new CallData(MultisigValidatorABI);
         const data = calldata.compile("get_public_keys", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "get_public_keys",
           data
         );
@@ -671,7 +694,7 @@ describe.each([data[1]])(
           old_public_key: conf.accounts[thirdAccountID].publicKey,
         });
         const { transaction_hash } = await smartrAccount.executeOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "remove_public_key",
           data
         );
@@ -688,7 +711,7 @@ describe.each([data[1]])(
         const calldata = new CallData(MultisigValidatorABI);
         const data = calldata.compile("get_public_keys", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("MultisigValidator"),
+          moduleClassHash(moduleClassNames.MultisigValidator),
           "get_public_keys",
           data
         );

--- a/sdks/__tests__/module/src/secondary.test.ts
+++ b/sdks/__tests__/module/src/secondary.test.ts
@@ -11,6 +11,7 @@ import {
   initial_StrkTransfer,
   ETH,
   STRK,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -19,6 +20,7 @@ import {
   deployAccount,
   accountAddress,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { RpcProvider, CallData, EthSigner, UniversalDetails } from "starknet";
 import {
@@ -26,6 +28,7 @@ import {
   classHash as moduleClassHash,
   EthModule,
   P256Module,
+  classNames as moduleClassNames,
 } from "../../../module/src";
 import { P256Signer } from "@0xknwn/starknet-module";
 import { StarkValidatorABI } from "@0xknwn/starknet-modular-account";
@@ -50,7 +53,7 @@ const dataset = [
         "258172356515136873455592221375042794236",
         "69849287226094710129367771214955413606",
       ],
-      className: "EthValidator" as "EthValidator",
+      className: moduleClassNames.EthValidator as moduleClassNames,
       module: EthModule,
       signer: EthSigner,
     },
@@ -73,7 +76,7 @@ const dataset = [
         "258172356515136873455592221375042794236",
         "69849287226094710129367771214955413606",
       ],
-      className: "EthValidator" as "EthValidator",
+      className: moduleClassNames.EthValidator as moduleClassNames,
       module: EthModule,
       signer: EthSigner,
     },
@@ -98,7 +101,7 @@ const dataset = [
         "230988565823064299531546210785320445498",
         "202889101106158949967186230758848275236",
       ],
-      className: "P256Validator" as "P256Validator",
+      className: moduleClassNames.P256Validator as moduleClassNames,
       module: P256Module,
       signer: P256Signer,
     },
@@ -123,7 +126,7 @@ const dataset = [
         "230988565823064299531546210785320445498",
         "202889101106158949967186230758848275236",
       ],
-      className: "P256Validator" as "P256Validator",
+      className: moduleClassNames.P256Validator as moduleClassNames,
       module: P256Module,
       signer: P256Signer,
     },
@@ -158,10 +161,10 @@ describe.each([dataset[1], dataset[3]])(
       async () => {
         const conf = config(env);
         const account = testAccounts(conf)[accountID];
-        const c = await declareHelperClass(account, "Counter", {
+        const c = await declareHelperClass(account, helperClassNames.Counter, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(helperClassHash("Counter"));
+        expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
       },
       default_timeout
     );
@@ -187,10 +190,16 @@ describe.each([dataset[1], dataset[3]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "StarkValidator", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("StarkValidator"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.StarkValidator,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.StarkValidator)
+        );
       },
       default_timeout
     );
@@ -200,10 +209,16 @@ describe.each([dataset[1], dataset[3]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.SmartrAccount,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.SmartrAccount)
+        );
       },
       default_timeout
     );
@@ -216,12 +231,18 @@ describe.each([dataset[1], dataset[3]])(
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const publicKey = conf.accounts[accountID].publicKey;
         const privateKey = conf.accounts[accountID].privateKey;
-        const starkValidatorClassHash = accountClassHash("StarkValidator");
+        const starkValidatorClassHash = accountClassHash(
+          accountClassNames.StarkValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
-        const address = accountAddress("SmartrAccount", publicKey, calldata);
+        const address = accountAddress(
+          accountClassNames.SmartrAccount,
+          publicKey,
+          calldata
+        );
         const TOKEN = fees === "WEI" ? ETH : STRK;
         const initial_transfer =
           fees === "WEI" ? initial_EthTransfer : initial_StrkTransfer;
@@ -248,20 +269,22 @@ describe.each([dataset[1], dataset[3]])(
       async () => {
         const conf = config(env);
         const publicKey = conf.accounts[accountID].publicKey;
-        const starkValidatorClassHash = accountClassHash("StarkValidator");
+        const starkValidatorClassHash = accountClassHash(
+          accountClassNames.StarkValidator
+        );
         const calldata = new CallData(SmartrAccountABI).compile("constructor", {
           core_validator: starkValidatorClassHash,
           args: [publicKey],
         });
         const address = await deployAccount(
           smartrAccount,
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           publicKey,
           calldata,
           { version: version.deploy_account }
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", publicKey, calldata)
+          accountAddress(accountClassNames.SmartrAccount, publicKey, calldata)
         );
       },
       default_timeout
@@ -274,7 +297,7 @@ describe.each([dataset[1], dataset[3]])(
         const calldata = new CallData(StarkValidatorABI);
         const data = calldata.compile("get_public_key", {});
         const c = await smartrAccount.callOnModule(
-          accountClassHash("StarkValidator"),
+          accountClassHash(accountClassNames.StarkValidator),
           "get_public_key",
           data
         );

--- a/sdks/__tests__/module/src/stark.test.ts
+++ b/sdks/__tests__/module/src/stark.test.ts
@@ -11,6 +11,7 @@ import {
   STRK,
   initial_EthTransfer,
   initial_StrkTransfer,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 import {
   declareClass as declareAccountClass,
@@ -19,11 +20,11 @@ import {
   deployAccount,
   accountAddress,
   StarkValidatorABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
-import { RpcProvider, CallData, cairo, Signer } from "starknet";
+import { RpcProvider, CallData, Signer } from "starknet";
 import {
   declareClass as declareModuleClass,
-  classHash as moduleClassHash,
   StarkModule,
 } from "@0xknwn/starknet-module";
 
@@ -60,10 +61,10 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const account = testAccounts(conf)[accountID];
-        const c = await declareHelperClass(account, "Counter", {
+        const c = await declareHelperClass(account, helperClassNames.Counter, {
           version: version.declare,
         });
-        expect(c.classHash).toEqual(helperClassHash("Counter"));
+        expect(c.classHash).toEqual(helperClassHash(helperClassNames.Counter));
       },
       default_timeout
     );
@@ -89,10 +90,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareModuleClass(a, "StarkValidator", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(moduleClassHash("StarkValidator"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.StarkValidator,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.StarkValidator)
+        );
       },
       default_timeout
     );
@@ -102,10 +109,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareAccountClass(a, "SmartrAccount", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(accountClassHash("SmartrAccount"));
+        const c = await declareAccountClass(
+          a,
+          accountClassNames.SmartrAccount,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          accountClassHash(accountClassNames.SmartrAccount)
+        );
       },
       default_timeout
     );
@@ -117,14 +130,16 @@ describe.each([data[1]])(
         const sender = testAccounts(conf)[accountID];
         const p = new RpcProvider({ nodeUrl: conf.providerURL });
         const privateKey = conf.accounts[accountID].privateKey;
-        const moduleValidatorClassHash = moduleClassHash("StarkValidator");
+        const moduleValidatorClassHash = accountClassHash(
+          accountClassNames.StarkValidator
+        );
         const calldata = [
           moduleValidatorClassHash,
           "0x1",
           smartAccountPublicKey,
         ];
         const address = accountAddress(
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           smartAccountPublicKey,
           calldata
         );
@@ -170,7 +185,9 @@ describe.each([data[1]])(
       `[${fees}][stark]: deploys a SmartrAccount account`,
       async () => {
         const conf = config(env);
-        const moduleValidatorClassHash = moduleClassHash("StarkValidator");
+        const moduleValidatorClassHash = accountClassHash(
+          accountClassNames.StarkValidator
+        );
         const calldata = [
           moduleValidatorClassHash,
           "0x1",
@@ -178,7 +195,7 @@ describe.each([data[1]])(
         ];
         const address = await deployAccount(
           smartrAccount,
-          "SmartrAccount",
+          accountClassNames.SmartrAccount,
           smartAccountPublicKey,
           calldata,
           {
@@ -186,7 +203,11 @@ describe.each([data[1]])(
           }
         );
         expect(address).toEqual(
-          accountAddress("SmartrAccount", smartAccountPublicKey, calldata)
+          accountAddress(
+            accountClassNames.SmartrAccount,
+            smartAccountPublicKey,
+            calldata
+          )
         );
       },
       default_timeout
@@ -199,7 +220,7 @@ describe.each([data[1]])(
         const calldata = new CallData(StarkValidatorABI);
         const nestedCalldata = calldata.compile("get_public_key", {});
         const c = await smartrAccount.callOnModule(
-          moduleClassHash("StarkValidator"),
+          accountClassHash(accountClassNames.StarkValidator),
           "get_public_key",
           nestedCalldata
         );
@@ -265,7 +286,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const output = await smartrAccount.isModule(
-          moduleClassHash("StarkValidator")
+          accountClassHash(accountClassNames.StarkValidator)
         );
         expect(output).toBe(true);
       },
@@ -366,7 +387,7 @@ describe.each([data[1]])(
         }
         try {
           await await smartrAccount.removeModule(
-            moduleClassHash("StarkValidator")
+            accountClassHash(accountClassNames.StarkValidator)
           );
           expect(true).toBe(false);
         } catch (e) {
@@ -383,7 +404,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const output = await smartrAccount.isModule(
-          moduleClassHash("StarkValidator")
+          accountClassHash(accountClassNames.StarkValidator)
         );
         expect(output).toBe(true);
       },

--- a/sdks/account/package.json
+++ b/sdks/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-modular-account",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/sdks/account/src/class.ts
+++ b/sdks/account/src/class.ts
@@ -5,12 +5,19 @@ import {
   Account,
   UniversalDetails,
 } from "starknet";
+import { Buffer } from "buffer";
 import { data as StarkValidatorContract } from "./artifacts/StarkValidator-contract";
 import { data as StarkValidatorCompiled } from "./artifacts/StarkValidator-compiled";
 import { data as SimpleValidatorContract } from "./artifacts/SimpleValidator-contract";
 import { data as SimpleValidatorCompiled } from "./artifacts/SimpleValidator-compiled";
 import { data as SmartrAccountContract } from "./artifacts/SmartrAccount-contract";
 import { data as SmartrAccountCompiled } from "./artifacts/SmartrAccount-compiled";
+
+export enum classNames {
+  StarkValidator = "StarkValidator",
+  SimpleValidator = "SimpleValidator",
+  SmartrAccount = "SmartrAccount",
+}
 
 /**
  * Computes the hash of the requested class that is part of the
@@ -21,21 +28,16 @@ import { data as SmartrAccountCompiled } from "./artifacts/SmartrAccount-compile
  * `scarb build` command at the root of the project.
  *
  */
-export const classHash = (
-  className:
-    | "StarkValidator"
-    | "SmartrAccount"
-    | "SimpleValidator" = "SmartrAccount"
-) => {
+export const classHash = (className: classNames = classNames.SmartrAccount) => {
   let contract: string = "";
   switch (className) {
-    case "StarkValidator":
+    case classNames.StarkValidator:
       contract = StarkValidatorContract;
       break;
-    case "SimpleValidator":
+    case classNames.SimpleValidator:
       contract = SimpleValidatorContract;
       break;
-    case "SmartrAccount":
+    case classNames.SmartrAccount:
       contract = SmartrAccountContract;
       break;
     default:
@@ -63,7 +65,7 @@ export const classHash = (
  */
 export const declareClass = async (
   account: Account,
-  className: "StarkValidator" | "SmartrAccount" | "SimpleValidator",
+  className: classNames,
   details?: UniversalDetails
 ) => {
   const HelperClassHash = classHash(className);
@@ -77,13 +79,13 @@ export const declareClass = async (
 
   let contract: string = "";
   switch (className) {
-    case "StarkValidator":
+    case classNames.StarkValidator:
       contract = StarkValidatorContract;
       break;
-    case "SimpleValidator":
+    case classNames.SimpleValidator:
       contract = SimpleValidatorContract;
       break;
-    case "SmartrAccount":
+    case classNames.SmartrAccount:
       contract = SmartrAccountContract;
       break;
     default:
@@ -92,13 +94,13 @@ export const declareClass = async (
 
   let compiled: string = "";
   switch (className) {
-    case "StarkValidator":
+    case classNames.StarkValidator:
       compiled = StarkValidatorCompiled;
       break;
-    case "SimpleValidator":
+    case classNames.SimpleValidator:
       compiled = SimpleValidatorCompiled;
       break;
-    case "SmartrAccount":
+    case classNames.SmartrAccount:
       compiled = SmartrAccountCompiled;
       break;
     default:

--- a/sdks/account/src/contract.ts
+++ b/sdks/account/src/contract.ts
@@ -1,6 +1,7 @@
 import { Account, Contract, hash, num, UniversalDetails } from "starknet";
 import { classHash } from "./class";
 import { ETH, STRK } from "./natives";
+import { classNames } from "./class";
 /**
  * Calculates the account address for a given account name, public key, and constructor call data.
  * @param class_hash - The class hash of the contract.
@@ -11,7 +12,7 @@ import { ETH, STRK } from "./natives";
  * `scarb build` command at the root of the project.
  */
 export const accountAddress = (
-  accountName: "SmartrAccount",
+  accountName: classNames.SmartrAccount,
   salt: string,
   constructorCallData: string[]
 ): string => {
@@ -36,7 +37,7 @@ export const accountAddress = (
  */
 export const deployAccount = async (
   deployerAccount: Account,
-  accountName: "SmartrAccount",
+  accountName: classNames.SmartrAccount,
   salt: string,
   constructorCalldata: any[],
   details?: UniversalDetails

--- a/sdks/module-sessionkey/package.json
+++ b/sdks/module-sessionkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-module-sessionkey",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/sdks/module-sessionkey/src/class.ts
+++ b/sdks/module-sessionkey/src/class.ts
@@ -5,6 +5,7 @@ import {
   Account,
   UniversalDetails,
 } from "starknet";
+import { Buffer } from "buffer";
 import { data as SessionKeyValidatorContract } from "./artifacts/SessionKeyValidator-contract";
 import { data as SessionKeyValidatorCompiled } from "./artifacts/SessionKeyValidator-compiled";
 

--- a/sdks/module/package.json
+++ b/sdks/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-module",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
+    "buffer": "^6.0.3",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",

--- a/sdks/module/src/class.ts
+++ b/sdks/module/src/class.ts
@@ -38,14 +38,7 @@ export enum classNames {
  * `scarb build` command at the root of the project.
  *
  */
-export const classHash = (
-  className:
-    | classNames
-    | coreClassNames.SimpleValidator = classNames.EthValidator
-) => {
-  if (className === coreClassNames.SimpleValidator) {
-    return coreClassHash(coreClassNames.SimpleValidator);
-  }
+export const classHash = (className: classNames = classNames.EthValidator) => {
   let contract: string = "";
   switch (className) {
     case classNames.GuardedValidator:
@@ -85,12 +78,9 @@ export const classHash = (
  */
 export const declareClass = async (
   account: Account,
-  className: classNames | coreClassNames.SimpleValidator,
+  className: classNames,
   details?: UniversalDetails
 ) => {
-  if (className === coreClassNames.SimpleValidator) {
-    return coreDeclareClass(account, coreClassNames.SimpleValidator, details);
-  }
   const HelperClassHash = classHash(className);
 
   try {

--- a/sdks/module/src/class.ts
+++ b/sdks/module/src/class.ts
@@ -5,6 +5,7 @@ import {
   Account,
   UniversalDetails,
 } from "starknet";
+import { Buffer } from "buffer";
 import { data as GuardedValidatorContract } from "./artifacts/GuardedValidator-contract";
 import { data as GuardedValidatorCompiled } from "./artifacts/GuardedValidator-compiled";
 import { data as EthValidatorContract } from "./artifacts/EthValidator-contract";
@@ -16,9 +17,17 @@ import { data as P256ValidatorCompiled } from "./artifacts/P256Validator-compile
 import {
   classHash as coreClassHash,
   declareClass as coreDeclareClass,
+  classNames as coreClassNames,
 } from "@0xknwn/starknet-modular-account";
 export const __module_validate__ =
   "0x119c88dea7ff05dbe71c36247fc6682116f6dafa24089373d49aca7b2657017";
+
+export enum classNames {
+  EthValidator = "EthValidator",
+  GuardedValidator = "GuardedValidator",
+  MultisigValidator = "MultisigValidator",
+  P256Validator = "P256Validator",
+}
 
 /**
  * Computes the hash of the requested class that is part of the
@@ -31,27 +40,24 @@ export const __module_validate__ =
  */
 export const classHash = (
   className:
-    | "EthValidator"
-    | "GuardedValidator"
-    | "MultisigValidator"
-    | "P256Validator"
-    | "StarkValidator" = "EthValidator"
+    | classNames
+    | coreClassNames.SimpleValidator = classNames.EthValidator
 ) => {
-  if (className === "StarkValidator") {
-    return coreClassHash("StarkValidator");
+  if (className === coreClassNames.SimpleValidator) {
+    return coreClassHash(coreClassNames.SimpleValidator);
   }
   let contract: string = "";
   switch (className) {
-    case "GuardedValidator":
+    case classNames.GuardedValidator:
       contract = GuardedValidatorContract;
       break;
-    case "EthValidator":
+    case classNames.EthValidator:
       contract = EthValidatorContract;
       break;
-    case "MultisigValidator":
+    case classNames.MultisigValidator:
       contract = MultisigValidatorContract;
       break;
-    case "P256Validator":
+    case classNames.P256Validator:
       contract = P256ValidatorContract;
       break;
     default:
@@ -79,16 +85,11 @@ export const classHash = (
  */
 export const declareClass = async (
   account: Account,
-  className:
-    | "EthValidator"
-    | "GuardedValidator"
-    | "MultisigValidator"
-    | "P256Validator"
-    | "StarkValidator",
+  className: classNames | coreClassNames.SimpleValidator,
   details?: UniversalDetails
 ) => {
-  if (className === "StarkValidator") {
-    return coreDeclareClass(account, "StarkValidator", details);
+  if (className === coreClassNames.SimpleValidator) {
+    return coreDeclareClass(account, coreClassNames.SimpleValidator, details);
   }
   const HelperClassHash = classHash(className);
 
@@ -101,16 +102,16 @@ export const declareClass = async (
 
   let contract: string = "";
   switch (className) {
-    case "EthValidator":
+    case classNames.EthValidator:
       contract = EthValidatorContract;
       break;
-    case "GuardedValidator":
+    case classNames.GuardedValidator:
       contract = GuardedValidatorContract;
       break;
-    case "MultisigValidator":
+    case classNames.MultisigValidator:
       contract = MultisigValidatorContract;
       break;
-    case "P256Validator":
+    case classNames.P256Validator:
       contract = P256ValidatorContract;
       break;
     default:
@@ -119,16 +120,16 @@ export const declareClass = async (
 
   let compiled: string = "";
   switch (className) {
-    case "EthValidator":
+    case classNames.EthValidator:
       compiled = EthValidatorCompiled;
       break;
-    case "GuardedValidator":
+    case classNames.GuardedValidator:
       compiled = GuardedValidatorCompiled;
       break;
-    case "MultisigValidator":
+    case classNames.MultisigValidator:
       compiled = MultisigValidatorCompiled;
       break;
-    case "P256Validator":
+    case classNames.P256Validator:
       compiled = P256ValidatorCompiled;
       break;
     default:

--- a/sdks/module/src/eth.ts
+++ b/sdks/module/src/eth.ts
@@ -1,7 +1,7 @@
 import { Call } from "starknet";
 
 import { AccountModuleInterface } from "@0xknwn/starknet-modular-account";
-import { classHash } from "./class";
+import { classHash, classNames } from "./class";
 
 export class EthModule implements AccountModuleInterface {
   protected accountAddress: string;
@@ -10,7 +10,7 @@ export class EthModule implements AccountModuleInterface {
   }
 
   prefix(calls: Call[] | Call) {
-    let calldata: string[] = [classHash("EthValidator")];
+    let calldata: string[] = [classHash(classNames.EthValidator)];
     calldata.unshift(`0x${calldata.length.toString(16)}`);
     return {
       entrypoint: "__module_validate__",

--- a/sdks/module/src/multisig.ts
+++ b/sdks/module/src/multisig.ts
@@ -1,7 +1,7 @@
 import { Call } from "starknet";
 
 import { AccountModuleInterface } from "@0xknwn/starknet-modular-account";
-import { classHash } from "./class";
+import { classHash, classNames } from "./class";
 
 export class MultisigModule implements AccountModuleInterface {
   protected accountAddress: string;
@@ -10,7 +10,7 @@ export class MultisigModule implements AccountModuleInterface {
   }
 
   prefix(calls: Call[] | Call) {
-    let calldata: string[] = [classHash("MultisigValidator")];
+    let calldata: string[] = [classHash(classNames.MultisigValidator)];
     calldata.unshift(`0x${calldata.length.toString(16)}`);
     return {
       entrypoint: "__module_validate__",

--- a/sdks/module/src/p256.ts
+++ b/sdks/module/src/p256.ts
@@ -1,7 +1,7 @@
 import { Call } from "starknet";
 
 import { AccountModuleInterface } from "@0xknwn/starknet-modular-account";
-import { classHash } from "./class";
+import { classHash, classNames } from "./class";
 
 export class P256Module implements AccountModuleInterface {
   protected accountAddress: string;
@@ -10,7 +10,7 @@ export class P256Module implements AccountModuleInterface {
   }
 
   prefix(calls: Call[] | Call) {
-    let calldata: string[] = [classHash("P256Validator")];
+    let calldata: string[] = [classHash(classNames.P256Validator)];
     calldata.unshift(`0x${calldata.length.toString(16)}`);
     return {
       entrypoint: "__module_validate__",

--- a/sdks/module/src/stark.ts
+++ b/sdks/module/src/stark.ts
@@ -3,6 +3,7 @@ import { Call } from "starknet";
 import {
   AccountModuleInterface,
   classHash,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 
 export class StarkModule implements AccountModuleInterface {
@@ -12,7 +13,7 @@ export class StarkModule implements AccountModuleInterface {
   }
 
   prefix(calls: Call[] | Call) {
-    let calldata: string[] = [classHash("StarkValidator")];
+    let calldata: string[] = [classHash(classNames.StarkValidator)];
     calldata.unshift(`0x${calldata.length.toString(16)}`);
     return {
       entrypoint: "__module_validate__",


### PR DESCRIPTION
## Summary

This PR fixes the fact that browsers do not have the `Buffer` object and uses enum in classNames to improve type checks.

## Impacts on the signers

This is to correct a bug on the web signer

## Changes

- Add the "buffer" packages in the dependencies and import `Buffer`from it to have a polyfill on the class
- Add enums instead of strings to reference classNames
- Remove StarkValidator and SimpleValidator from the module package
- Prepare the package upgrade to ship v0.2.2

## Checklist:

- [ ] Link the associated issue
- [x] Perform a self-review of the code
- [x] Rebase to the head of the `develop` branch from 0xknow/starknet-modular-account
- [x] Document the changes in code
- [ ] Make sure the code is properly formatted by running `scarb fmt`
- [ ] Add unit tests with starknet foundry
- [x] Add integration tests with starknet.js and jest
- [x] Pass all the tests
