### PR TITLE
move documentation-examples to SDKs v0.2.2

### DIFF
--- a/docs/others/version-checklist.md
+++ b/docs/others/version-checklist.md
@@ -34,7 +34,7 @@ npm run test:scarb
 6. adding the version in the package.json
 
 ```shell
-npm run update-versions -- 0.2.2
+npm run update-versions -- 0.2.3
 ```
 
 7. Merge all the changes to the `develop` branch of the repository
@@ -50,7 +50,7 @@ npm run update-versions -- 0.2.2
 git fetch -p
 git checkout develop
 git pull
-git reset --hard v0.2.2
+git reset --hard v0.2.3
 npm run build
 npm run registry
 ```

--- a/docs/others/version-checklist.md
+++ b/docs/others/version-checklist.md
@@ -34,7 +34,7 @@ npm run test:scarb
 6. adding the version in the package.json
 
 ```shell
-npm run update-versions -- 0.2.1
+npm run update-versions -- 0.2.2
 ```
 
 7. Merge all the changes to the `develop` branch of the repository
@@ -50,7 +50,7 @@ npm run update-versions -- 0.2.1
 git fetch -p
 git checkout develop
 git pull
-git reset --hard v0.2.1
+git reset --hard v0.2.2
 npm run build
 npm run registry
 ```

--- a/experiments/documentation-examples/package.json
+++ b/experiments/documentation-examples/package.json
@@ -10,10 +10,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@0xknwn/starknet-modular-account": "^0.2.1",
-    "@0xknwn/starknet-module": "^0.2.1",
-    "@0xknwn/starknet-module-sessionkey": "^0.2.1",
-    "@0xknwn/starknet-test-helpers": "^0.2.1"
+    "@0xknwn/starknet-modular-account": "^0.2.2",
+    "@0xknwn/starknet-module": "^0.2.2",
+    "@0xknwn/starknet-module-sessionkey": "^0.2.2",
+    "@0xknwn/starknet-test-helpers": "^0.2.2"
   },
   "devDependencies": {
     "starknet": "^6.21.1"

--- a/experiments/documentation-examples/src/01-check-class.ts
+++ b/experiments/documentation-examples/src/01-check-class.ts
@@ -1,5 +1,5 @@
 // file src/01-check-class.ts
-import { classHash } from "@0xknwn/starknet-modular-account";
+import { classHash, classNames } from "@0xknwn/starknet-modular-account";
 
-console.log("smartrAccount class hash:", classHash("SmartrAccount"));
-console.log("starkValidator class hash:", classHash("StarkValidator"));
+console.log("smartrAccount class hash:", classHash(classNames.SmartrAccount));
+console.log("starkValidator class hash:", classHash(classNames.StarkValidator));

--- a/experiments/documentation-examples/src/01-declare-class.ts
+++ b/experiments/documentation-examples/src/01-declare-class.ts
@@ -1,6 +1,6 @@
 // file src/01-declare-class.ts
 import { RpcProvider, Account } from "starknet";
-import { declareClass } from "@0xknwn/starknet-modular-account";
+import { declareClass, classNames } from "@0xknwn/starknet-modular-account";
 
 // these are the settings for the devnet with --seed=0
 // change them to mee your requirements
@@ -21,13 +21,13 @@ const main = async () => {
 
   const { classHash: smartrAccountClassHash } = await declareClass(
     account,
-    "SmartrAccount"
+    classNames.SmartrAccount
   );
   console.log("smartrAccount class hash:", smartrAccountClassHash);
 
   const { classHash: starkValidatorClassHash } = await declareClass(
     account,
-    "StarkValidator"
+    classNames.StarkValidator
   );
   console.log("starkValidator class hash:", starkValidatorClassHash);
 };

--- a/experiments/documentation-examples/src/01-deploy-account.ts
+++ b/experiments/documentation-examples/src/01-deploy-account.ts
@@ -6,6 +6,7 @@ import {
   deployAccount,
   SmartrAccount,
   SmartrAccountABI,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 
 // these are the settings for the devnet with --seed=0
@@ -17,13 +18,13 @@ const main = async () => {
   const provider = new RpcProvider({ nodeUrl: providerURL });
   const smartrSigner = new Signer(smartrAccountPrivateKey);
   const smartrAccountPublicKey = await smartrSigner.getPubKey();
-  const starkValidatorClassHash = classHash("StarkValidator");
+  const starkValidatorClassHash = classHash(classNames.StarkValidator);
   const calldata = new CallData(SmartrAccountABI).compile("constructor", {
     core_validator: starkValidatorClassHash,
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    classNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -37,7 +38,7 @@ const main = async () => {
   );
   const address = await deployAccount(
     smartrAccount,
-    "SmartrAccount",
+    classNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );

--- a/experiments/documentation-examples/src/01-load-strk.ts
+++ b/experiments/documentation-examples/src/01-load-strk.ts
@@ -11,6 +11,7 @@ import {
   accountAddress,
   classHash,
   SmartrAccountABI,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 import { ABI as ERC20ABI } from "./abi/ERC20";
 
@@ -35,13 +36,13 @@ const main = async () => {
   );
   const smartrSigner = new Signer(smartrAccountPrivateKey);
   const smartrAccountPublicKey = await smartrSigner.getPubKey();
-  const starkValidatorClassHash = classHash("StarkValidator");
+  const starkValidatorClassHash = classHash(classNames.StarkValidator);
   const calldata = new CallData(SmartrAccountABI).compile("constructor", {
     core_validator: starkValidatorClassHash,
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    classNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );

--- a/experiments/documentation-examples/src/01-using-account.ts
+++ b/experiments/documentation-examples/src/01-using-account.ts
@@ -5,6 +5,7 @@ import {
   classHash,
   SmartrAccount,
   SmartrAccountABI,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 
 // these are the settings for the devnet with --seed=0
@@ -16,13 +17,13 @@ const main = async () => {
   const provider = new RpcProvider({ nodeUrl: providerURL });
   const smartrSigner = new Signer(smartrAccountPrivateKey);
   const smartrAccountPublicKey = await smartrSigner.getPubKey();
-  const starkValidatorClassHash = classHash("StarkValidator");
+  const starkValidatorClassHash = classHash(classNames.StarkValidator);
   const calldata = new CallData(SmartrAccountABI).compile("constructor", {
     core_validator: starkValidatorClassHash,
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    classNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );

--- a/experiments/documentation-examples/src/02-check-class.ts
+++ b/experiments/documentation-examples/src/02-check-class.ts
@@ -1,4 +1,4 @@
 // file src/02-check-class.ts
-import { classHash } from "@0xknwn/starknet-modular-account";
+import { classHash, classNames } from "@0xknwn/starknet-modular-account";
 
-console.log("starkValidator class hash:", classHash("StarkValidator"));
+console.log("starkValidator class hash:", classHash(classNames.StarkValidator));

--- a/experiments/documentation-examples/src/02-init.ts
+++ b/experiments/documentation-examples/src/02-init.ts
@@ -3,6 +3,7 @@ import {
   accountAddress,
   classHash,
   SmartrAccountABI,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 import {
   counterAddress as helperCounterAddress,
@@ -18,13 +19,13 @@ export const init = async () => {
   // compute the smartrAccount details
   const smartrSigner = new Signer(smartrAccountPrivateKey);
   const smartrAccountPublicKey = await smartrSigner.getPubKey();
-  const starkValidatorClassHash = classHash("StarkValidator");
+  const starkValidatorClassHash = classHash(classNames.StarkValidator);
   const calldata = new CallData(SmartrAccountABI).compile("constructor", {
     core_validator: starkValidatorClassHash,
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    classNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );

--- a/experiments/documentation-examples/src/02-module-installed.ts
+++ b/experiments/documentation-examples/src/02-module-installed.ts
@@ -1,5 +1,9 @@
 // file src/02-module-installed.ts
-import { SmartrAccount, classHash } from "@0xknwn/starknet-modular-account";
+import {
+  SmartrAccount,
+  classHash,
+  classNames,
+} from "@0xknwn/starknet-modular-account";
 import { init } from "./02-init";
 import { RpcProvider } from "starknet";
 
@@ -16,10 +20,12 @@ const main = async () => {
     "1",
     "0x3"
   );
-  const isInstalled = await account.isModule(classHash("StarkValidator"));
+  const isInstalled = await account.isModule(
+    classHash(classNames.StarkValidator)
+  );
   console.log(
     "module",
-    classHash("StarkValidator"),
+    classHash(classNames.StarkValidator),
     "is installed",
     isInstalled
   );

--- a/experiments/documentation-examples/src/02-registered-publickey.ts
+++ b/experiments/documentation-examples/src/02-registered-publickey.ts
@@ -3,6 +3,7 @@ import {
   StarkValidatorABI,
   SmartrAccount,
   classHash,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 import { init } from "./02-init";
 import { CallData, RpcProvider } from "starknet";
@@ -23,7 +24,7 @@ const main = async () => {
   const moduleCallData = new CallData(StarkValidatorABI);
   const calldata = await moduleCallData.compile("get_public_key", {});
   const publickey = await account.callOnModule(
-    classHash("StarkValidator"),
+    classHash(classNames.StarkValidator),
     "get_public_key",
     calldata
   );

--- a/experiments/documentation-examples/src/02-setup.ts
+++ b/experiments/documentation-examples/src/02-setup.ts
@@ -12,11 +12,13 @@ import {
   SmartrAccount,
   deployAccount,
   SmartrAccountABI,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 import { ABI as ERC20ABI } from "./abi/ERC20";
 import {
   declareClass as helperDeclareClass,
   deployCounter,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 
 const ozAccountAddress =
@@ -41,11 +43,11 @@ const main = async () => {
   // declare the classes
   const { classHash: smartrAccountClassHash } = await declareClass(
     account,
-    "SmartrAccount"
+    classNames.SmartrAccount
   );
   const { classHash: starkValidatorClassHash } = await declareClass(
     account,
-    "StarkValidator"
+    classNames.StarkValidator
   );
 
   // load ETH
@@ -56,7 +58,7 @@ const main = async () => {
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    classNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -83,7 +85,7 @@ const main = async () => {
   );
   const address = await deployAccount(
     smartrAccount,
-    "SmartrAccount",
+    classNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -96,7 +98,7 @@ const main = async () => {
   // deploy the Counter contract
   const { classHash: counterClassHash } = await helperDeclareClass(
     account,
-    "Counter"
+    helperClassNames.Counter
   );
   const counter = await deployCounter(account, account.address);
   console.log("Account address:", smartrAccountAddress);

--- a/experiments/documentation-examples/src/02-update-publickey.ts
+++ b/experiments/documentation-examples/src/02-update-publickey.ts
@@ -3,6 +3,7 @@ import {
   StarkValidatorABI,
   SmartrAccount,
   classHash,
+  classNames,
 } from "@0xknwn/starknet-modular-account";
 import { init } from "./02-init";
 import { CallData, RpcProvider, Signer } from "starknet";
@@ -29,7 +30,7 @@ const main = async () => {
     new_public_key: newAccountPublicKey,
   });
   const { transaction_hash } = await account.executeOnModule(
-    classHash("StarkValidator"),
+    classHash(classNames.StarkValidator),
     "set_public_key",
     calldata
   );

--- a/experiments/documentation-examples/src/03-add-publickeys.ts
+++ b/experiments/documentation-examples/src/03-add-publickeys.ts
@@ -6,6 +6,7 @@ import {
 import {
   MultisigValidatorABI,
   classHash as moduleClassHash,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./03-init";
 import { CallData, RpcProvider, Signer, hash, type Call } from "starknet";
@@ -25,7 +26,7 @@ const main = async () => {
     "1",
     "0x3"
   );
-  const module_class_hash = moduleClassHash("MultisigValidator");
+  const module_class_hash = moduleClassHash(moduleClassNames.MultisigValidator);
   const calls: Call[] = [];
   for (const privateKey of [secondAccountPrivateKey, thirdAccountPrivateKey]) {
     const signer = new Signer(privateKey);

--- a/experiments/documentation-examples/src/03-check-class.ts
+++ b/experiments/documentation-examples/src/03-check-class.ts
@@ -1,4 +1,10 @@
 // file src/03-check-class.ts
-import { classHash } from "@0xknwn/starknet-module";
+import {
+  classHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 
-console.log("MultisigValidator class hash:", classHash("MultisigValidator"));
+console.log(
+  "MultisigValidator class hash:",
+  classHash(moduleClassNames.MultisigValidator)
+);

--- a/experiments/documentation-examples/src/03-decrease-threshold.ts
+++ b/experiments/documentation-examples/src/03-decrease-threshold.ts
@@ -6,6 +6,7 @@ import {
 import {
   MultisigValidatorABI,
   classHash as moduleClassHash,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./03-init";
 import {
@@ -46,7 +47,7 @@ const main = async () => {
   });
   const accountCallData = new CallData(SmartrAccountABI);
   const calldata = accountCallData.compile("execute_on_module", {
-    class_hash: moduleClassHash("MultisigValidator"),
+    class_hash: moduleClassHash(moduleClassNames.MultisigValidator),
     call: {
       selector: hash.getSelectorFromName("set_threshold"),
       to: accountAddress,

--- a/experiments/documentation-examples/src/03-get-threshold.ts
+++ b/experiments/documentation-examples/src/03-get-threshold.ts
@@ -3,6 +3,7 @@ import { SmartrAccount } from "@0xknwn/starknet-modular-account";
 import {
   MultisigValidatorABI,
   classHash as moduleClassHash,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./03-init";
 import { CallData, RpcProvider } from "starknet";
@@ -23,7 +24,7 @@ const main = async () => {
   const moduleCallData = new CallData(MultisigValidatorABI);
   const calldata = await moduleCallData.compile("get_threshold", {});
   const threshold = await account.callOnModule(
-    moduleClassHash("MultisigValidator"),
+    moduleClassHash(moduleClassNames.MultisigValidator),
     "get_threshold",
     calldata
   );

--- a/experiments/documentation-examples/src/03-increase-threshold.ts
+++ b/experiments/documentation-examples/src/03-increase-threshold.ts
@@ -3,6 +3,7 @@ import { SmartrAccount } from "@0xknwn/starknet-modular-account";
 import {
   MultisigValidatorABI,
   classHash as moduleClassHash,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./03-init";
 import { CallData, RpcProvider } from "starknet";
@@ -25,7 +26,7 @@ const main = async () => {
     new_threshold: 2,
   });
   const { transaction_hash } = await account.executeOnModule(
-    moduleClassHash("MultisigValidator"),
+    moduleClassHash(moduleClassNames.MultisigValidator),
     "set_threshold",
     calldata
   );

--- a/experiments/documentation-examples/src/03-init.ts
+++ b/experiments/documentation-examples/src/03-init.ts
@@ -2,8 +2,12 @@ import { Signer, CallData } from "starknet";
 import {
   accountAddress,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
-import { classHash as moduleClassHash } from "@0xknwn/starknet-module";
+import {
+  classHash as moduleClassHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import {
   counterAddress as helperCounterAddress,
   CounterABI,
@@ -18,13 +22,15 @@ export const init = async () => {
   // compute the smartrAccount details
   const smartrSigner = new Signer(smartrAccountPrivateKey);
   const smartrAccountPublicKey = await smartrSigner.getPubKey();
-  const multisigValidatorClassHash = moduleClassHash("MultisigValidator");
+  const multisigValidatorClassHash = moduleClassHash(
+    moduleClassNames.MultisigValidator
+  );
   const calldata = new CallData(SmartrAccountABI).compile("constructor", {
     core_validator: multisigValidatorClassHash,
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );

--- a/experiments/documentation-examples/src/03-module-installed.ts
+++ b/experiments/documentation-examples/src/03-module-installed.ts
@@ -1,6 +1,9 @@
 // file src/03-module-installed.ts
 import { SmartrAccount } from "@0xknwn/starknet-modular-account";
-import { classHash } from "@0xknwn/starknet-module";
+import {
+  classHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import { init } from "./03-init";
 import { RpcProvider } from "starknet";
 
@@ -17,10 +20,12 @@ const main = async () => {
     "1",
     "0x3"
   );
-  const isInstalled = await account.isModule(classHash("MultisigValidator"));
+  const isInstalled = await account.isModule(
+    classHash(moduleClassNames.MultisigValidator)
+  );
   console.log(
     "module",
-    classHash("MultisigValidator"),
+    classHash(moduleClassNames.MultisigValidator),
     "is installed",
     isInstalled
   );

--- a/experiments/documentation-examples/src/03-registered-publickeys.ts
+++ b/experiments/documentation-examples/src/03-registered-publickeys.ts
@@ -3,6 +3,7 @@ import { SmartrAccount } from "@0xknwn/starknet-modular-account";
 import {
   MultisigValidatorABI,
   classHash as moduleClassHash,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./03-init";
 import { CallData, RpcProvider } from "starknet";
@@ -23,7 +24,7 @@ const main = async () => {
   const moduleCallData = new CallData(MultisigValidatorABI);
   const calldata = moduleCallData.compile("get_public_keys", {});
   const publickeysList = await account.callOnModule(
-    moduleClassHash("MultisigValidator"),
+    moduleClassHash(moduleClassNames.MultisigValidator),
     "get_public_keys",
     calldata
   );

--- a/experiments/documentation-examples/src/03-remove-publickeys.ts
+++ b/experiments/documentation-examples/src/03-remove-publickeys.ts
@@ -6,6 +6,7 @@ import {
 import {
   MultisigValidatorABI,
   classHash as moduleClassHash,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./03-init";
 import { CallData, RpcProvider, Signer, hash, type Call } from "starknet";
@@ -25,7 +26,7 @@ const main = async () => {
     "1",
     "0x3"
   );
-  const module_class_hash = moduleClassHash("MultisigValidator");
+  const module_class_hash = moduleClassHash(moduleClassNames.MultisigValidator);
   const calls: Call[] = [];
   for (const privateKey of [secondAccountPrivateKey, thirdAccountPrivateKey]) {
     const signer = new Signer(privateKey);

--- a/experiments/documentation-examples/src/03-setup.ts
+++ b/experiments/documentation-examples/src/03-setup.ts
@@ -12,12 +12,17 @@ import {
   SmartrAccount,
   deployAccount,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
-import { declareClass as declareModuleClass } from "@0xknwn/starknet-module";
+import {
+  declareClass as declareModuleClass,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import { ABI as ERC20ABI } from "./abi/ERC20";
 import {
   declareClass as helperDeclareClass,
   deployCounter,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 
 const ozAccountAddress =
@@ -40,10 +45,10 @@ const main = async () => {
   );
 
   // declare the classes
-  await declareClass(account, "SmartrAccount");
+  await declareClass(account, accountClassNames.SmartrAccount);
   const { classHash: moduleValidatorClassHash } = await declareModuleClass(
     account,
-    "MultisigValidator"
+    moduleClassNames.MultisigValidator
   );
 
   // load ETH
@@ -54,7 +59,7 @@ const main = async () => {
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -81,7 +86,7 @@ const main = async () => {
   );
   const address = await deployAccount(
     smartrAccount,
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -94,7 +99,7 @@ const main = async () => {
   // deploy the Counter contract
   const { classHash: counterClassHash } = await helperDeclareClass(
     account,
-    "Counter"
+    helperClassNames.Counter
   );
   const counter = await deployCounter(account, account.address);
   console.log("Account address:", smartrAccountAddress);

--- a/experiments/documentation-examples/src/04-add-module.ts
+++ b/experiments/documentation-examples/src/04-add-module.ts
@@ -1,6 +1,9 @@
 // file src/04-add-module.ts
 import { SmartrAccount } from "@0xknwn/starknet-modular-account";
-import { classHash } from "@0xknwn/starknet-module";
+import {
+  classHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import { init } from "./04-init";
 import { RpcProvider } from "starknet";
 
@@ -18,13 +21,20 @@ const main = async () => {
     "0x3"
   );
   const { transaction_hash } = await account.addModule(
-    classHash("EthValidator")
+    classHash(moduleClassNames.EthValidator)
   );
   const receipt = await account.waitForTransaction(transaction_hash);
   console.log("transaction succeeded", receipt.isSuccess());
 
-  const isInstalled = await account.isModule(classHash("EthValidator"));
-  console.log("module", classHash("EthValidator"), "is installed", isInstalled);
+  const isInstalled = await account.isModule(
+    classHash(moduleClassNames.EthValidator)
+  );
+  console.log(
+    "module",
+    classHash(moduleClassNames.EthValidator),
+    "is installed",
+    isInstalled
+  );
 };
 
 main()

--- a/experiments/documentation-examples/src/04-check-eth-validator.ts
+++ b/experiments/documentation-examples/src/04-check-eth-validator.ts
@@ -1,4 +1,10 @@
 // file src/04-check-eth-validator.ts
-import { classHash } from "@0xknwn/starknet-module";
+import {
+  classHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 
-console.log("Computed EthValidator class hash:", classHash("EthValidator"));
+console.log(
+  "Computed EthValidator class hash:",
+  classHash(moduleClassNames.EthValidator)
+);

--- a/experiments/documentation-examples/src/04-declare-eth-validator.ts
+++ b/experiments/documentation-examples/src/04-declare-eth-validator.ts
@@ -1,6 +1,9 @@
 // file src/04-declare-eth-validator.ts
 import { RpcProvider, Account } from "starknet";
-import { declareClass } from "@0xknwn/starknet-module";
+import {
+  declareClass,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 
 // these are the settings for the devnet with --seed=0
 // change them to mee your requirements
@@ -21,7 +24,7 @@ const main = async () => {
 
   const { classHash: ethValidatorClassHash } = await declareClass(
     account,
-    "EthValidator"
+    moduleClassNames.EthValidator
   );
   console.log("EthValidator class hash:", ethValidatorClassHash);
 };

--- a/experiments/documentation-examples/src/04-deploy-account.ts
+++ b/experiments/documentation-examples/src/04-deploy-account.ts
@@ -11,8 +11,12 @@ import {
   accountAddress,
   deployAccount,
   SmartrAccount,
+  classNames as accountClassName,
 } from "@0xknwn/starknet-modular-account";
-import { classHash as ethClassHash } from "@0xknwn/starknet-module";
+import {
+  classHash as ethClassHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import { init } from "./04-init";
 import { ABI as ERC20ABI } from "./abi/ERC20";
 const strkAddress =
@@ -47,9 +51,9 @@ const main = async () => {
   // Step 2 - Compute the account address
   const publicKeyHash = hash.computeHashOnElements(publicKeyArray);
   const computedAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassName.SmartrAccount,
     publicKeyHash,
-    [ethClassHash("EthValidator"), "0x4", ...publicKeyArray]
+    [ethClassHash(moduleClassNames.EthValidator), "0x4", ...publicKeyArray]
   );
 
   // Step 3 - Send STRK to the computed account address
@@ -82,9 +86,9 @@ const main = async () => {
   );
   const address = await deployAccount(
     ethAccount,
-    "SmartrAccount",
+    accountClassName.SmartrAccount,
     publicKeyHash,
-    [ethClassHash("EthValidator"), "0x4", ...publicKeyArray],
+    [ethClassHash(moduleClassNames.EthValidator), "0x4", ...publicKeyArray],
     {
       version: "0x3",
       resourceBounds: {

--- a/experiments/documentation-examples/src/04-execute-tx-core.ts
+++ b/experiments/documentation-examples/src/04-execute-tx-core.ts
@@ -2,10 +2,14 @@
 import {
   SmartrAccount,
   accountAddress,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { init, CounterABI } from "./04-init";
 import { RpcProvider, Contract, EthSigner, cairo, hash } from "starknet";
-import { classHash as ethClassHash } from "@0xknwn/starknet-module";
+import {
+  classHash as ethClassHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 const providerURL = "http://127.0.0.1:5050/rpc";
 const ethPrivateKey =
   "0xb28ebb20fb1015da6e6367d1b5dba9b52862a06dbb3a4022e4749b6987ac1bd2";
@@ -28,9 +32,9 @@ const main = async () => {
 
   const publicKeyHash = hash.computeHashOnElements(publicKeyArray);
   const computedAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     publicKeyHash,
-    [ethClassHash("EthValidator"), "0x4", ...publicKeyArray]
+    [ethClassHash(moduleClassNames.EthValidator), "0x4", ...publicKeyArray]
   );
 
   // execute the transaction

--- a/experiments/documentation-examples/src/04-get-publickey.ts
+++ b/experiments/documentation-examples/src/04-get-publickey.ts
@@ -3,6 +3,7 @@ import { SmartrAccount } from "@0xknwn/starknet-modular-account";
 import {
   EthValidatorABI,
   classHash as ethClassHash,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./04-init";
 import { CallData, RpcProvider } from "starknet";
@@ -23,7 +24,7 @@ const main = async () => {
   const moduleCallData = new CallData(EthValidatorABI);
   const calldata = moduleCallData.compile("get_public_key", {});
   const public_keys = await account.callOnModule(
-    ethClassHash("EthValidator"),
+    ethClassHash(moduleClassNames.EthValidator),
     "get_public_key",
     calldata
   );

--- a/experiments/documentation-examples/src/04-init.ts
+++ b/experiments/documentation-examples/src/04-init.ts
@@ -3,6 +3,7 @@ import {
   accountAddress,
   classHash,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import {
   counterAddress as helperCounterAddress,
@@ -11,21 +12,21 @@ import {
 
 const ozAccountAddress =
   "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691";
-  const ozAccountPrivateKey = "0x71d7bb07b9a64f6f78ac4c816aff4da9";
-  const smartrAccountPrivateKey = "0x1";
+const ozAccountPrivateKey = "0x71d7bb07b9a64f6f78ac4c816aff4da9";
+const smartrAccountPrivateKey = "0x1";
 
 export { CounterABI };
 export const init = async () => {
   // compute the smartrAccount details
   const smartrSigner = new Signer(smartrAccountPrivateKey);
   const smartrAccountPublicKey = await smartrSigner.getPubKey();
-  const starkValidatorClassHash = classHash("StarkValidator");
+  const starkValidatorClassHash = classHash(accountClassNames.StarkValidator);
   const calldata = new CallData(SmartrAccountABI).compile("constructor", {
     core_validator: starkValidatorClassHash,
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );

--- a/experiments/documentation-examples/src/04-register-publickey.ts
+++ b/experiments/documentation-examples/src/04-register-publickey.ts
@@ -1,6 +1,9 @@
 // file src/04-register-publickey.ts
 import { SmartrAccount } from "@0xknwn/starknet-modular-account";
-import { classHash as ethClassHash } from "@0xknwn/starknet-module";
+import {
+  classHash as ethClassHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import { EthSigner, cairo } from "starknet";
 import { init } from "./04-init";
 import { RpcProvider } from "starknet";
@@ -20,7 +23,7 @@ const main = async () => {
     "1",
     "0x3"
   );
-  const module_class_hash = ethClassHash("EthValidator");
+  const module_class_hash = ethClassHash(moduleClassNames.EthValidator);
   const signer = new EthSigner(ethPrivateKey);
   const publicKey = await signer.getPubKey();
   const coords = publicKey.slice(2, publicKey.length);

--- a/experiments/documentation-examples/src/04-remove-module.ts
+++ b/experiments/documentation-examples/src/04-remove-module.ts
@@ -1,6 +1,9 @@
 // file src/04-remove-module.ts
 import { SmartrAccount } from "@0xknwn/starknet-modular-account";
-import { classHash } from "@0xknwn/starknet-module";
+import {
+  classHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import { init } from "./04-init";
 import { RpcProvider } from "starknet";
 
@@ -18,15 +21,17 @@ const main = async () => {
     "0x3"
   );
   const { transaction_hash } = await account.removeModule(
-    classHash("EthValidator")
+    classHash(moduleClassNames.EthValidator)
   );
   const receipt = await account.waitForTransaction(transaction_hash);
   console.log("transaction succeeded", receipt.isSuccess());
 
-  const isInstalled = await account.isModule(classHash("EthValidator"));
+  const isInstalled = await account.isModule(
+    classHash(moduleClassNames.EthValidator)
+  );
   console.log(
     "module",
-    classHash("EthValidator"),
+    classHash(moduleClassNames.EthValidator),
     "has been removed",
     isInstalled
   );

--- a/experiments/documentation-examples/src/04-setup.ts
+++ b/experiments/documentation-examples/src/04-setup.ts
@@ -12,11 +12,13 @@ import {
   SmartrAccount,
   deployAccount,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { ABI as ERC20ABI } from "./abi/ERC20";
 import {
   declareClass as helperDeclareClass,
   deployCounter,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 
 const ozAccountAddress =
@@ -39,10 +41,10 @@ const main = async () => {
   );
 
   // declare the classes
-  await declareClass(account, "SmartrAccount");
+  await declareClass(account, accountClassNames.SmartrAccount);
   const { classHash: starkValidatorClassHash } = await declareClass(
     account,
-    "StarkValidator"
+    accountClassNames.StarkValidator
   );
 
   // load ETH
@@ -53,7 +55,7 @@ const main = async () => {
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -80,7 +82,7 @@ const main = async () => {
   );
   const address = await deployAccount(
     smartrAccount,
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -93,7 +95,7 @@ const main = async () => {
   // deploy the Counter contract
   const { classHash: counterClassHash } = await helperDeclareClass(
     account,
-    "Counter"
+    helperClassNames.Counter
   );
   const counter = await deployCounter(account, account.address);
   console.log("Account address:", smartrAccountAddress);

--- a/experiments/documentation-examples/src/05-add-module.ts
+++ b/experiments/documentation-examples/src/05-add-module.ts
@@ -1,6 +1,9 @@
 // file src/05-add-module.ts
 import { SmartrAccount } from "@0xknwn/starknet-modular-account";
-import { classHash } from "@0xknwn/starknet-module";
+import {
+  classHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import { init } from "./05-init";
 import { RpcProvider } from "starknet";
 
@@ -21,15 +24,17 @@ const main = async () => {
     "0x3"
   );
   const { transaction_hash } = await account.addModule(
-    classHash("P256Validator")
+    classHash(moduleClassNames.P256Validator)
   );
   const receipt = await account.waitForTransaction(transaction_hash);
   console.log("transaction succeeded", receipt.isSuccess());
 
-  const isInstalled = await account.isModule(classHash("P256Validator"));
+  const isInstalled = await account.isModule(
+    classHash(moduleClassNames.P256Validator)
+  );
   console.log(
     "module",
-    classHash("P256Validator"),
+    classHash(moduleClassNames.P256Validator),
     "is installed:",
     isInstalled
   );

--- a/experiments/documentation-examples/src/05-check-p256-validator.ts
+++ b/experiments/documentation-examples/src/05-check-p256-validator.ts
@@ -1,4 +1,10 @@
 // file src/05-check-p256-validator.ts
-import { classHash } from "@0xknwn/starknet-module";
+import {
+  classHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 
-console.log("Computed P256Validator class hash:", classHash("P256Validator"));
+console.log(
+  "Computed P256Validator class hash:",
+  classHash(moduleClassNames.P256Validator)
+);

--- a/experiments/documentation-examples/src/05-declare-p256-validator.ts
+++ b/experiments/documentation-examples/src/05-declare-p256-validator.ts
@@ -1,6 +1,9 @@
 // file src/05-declare-p256-validator.ts
 import { RpcProvider, Account } from "starknet";
-import { declareClass } from "@0xknwn/starknet-module";
+import {
+  declareClass,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 
 // these are the settings for the devnet with --seed=0
 // change them to mee your requirements
@@ -11,11 +14,17 @@ const providerURL = "http://127.0.0.1:5050/rpc";
 
 const main = async () => {
   const provider = new RpcProvider({ nodeUrl: providerURL });
-  const account = new Account(provider, ozAccountAddress, ozPrivateKey, "1", "0x3");
+  const account = new Account(
+    provider,
+    ozAccountAddress,
+    ozPrivateKey,
+    "1",
+    "0x3"
+  );
 
   const { classHash: p256ValidatorClassHash } = await declareClass(
     account,
-    "P256Validator",
+    moduleClassNames.P256Validator
   );
   console.log("P256Validator class hash:", p256ValidatorClassHash);
 };

--- a/experiments/documentation-examples/src/05-deploy-account.ts
+++ b/experiments/documentation-examples/src/05-deploy-account.ts
@@ -4,10 +4,12 @@ import {
   accountAddress,
   deployAccount,
   SmartrAccount,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import {
   classHash as P256ClassHash,
   P256Signer,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./05-init";
 import { ABI as ERC20ABI } from "./abi/ERC20";
@@ -42,9 +44,9 @@ const main = async () => {
   // Step 2 - Compute the account address
   const publicKeyHash = hash.computeHashOnElements(publicKeyArray);
   const computedAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     publicKeyHash,
-    [P256ClassHash("P256Validator"), "0x4", ...publicKeyArray]
+    [P256ClassHash(moduleClassNames.P256Validator), "0x4", ...publicKeyArray]
   );
 
   // Step 3 - Send STRK to the computed account address
@@ -77,9 +79,9 @@ const main = async () => {
   );
   const address = await deployAccount(
     p256Account,
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     publicKeyHash,
-    [P256ClassHash("P256Validator"), "0x4", ...publicKeyArray],
+    [P256ClassHash(moduleClassNames.P256Validator), "0x4", ...publicKeyArray],
     {
       version: "0x3",
       resourceBounds: {

--- a/experiments/documentation-examples/src/05-execute-tx-core.ts
+++ b/experiments/documentation-examples/src/05-execute-tx-core.ts
@@ -2,12 +2,14 @@
 import {
   SmartrAccount,
   accountAddress,
+  classNames as accountlassNames,
 } from "@0xknwn/starknet-modular-account";
 import { init, CounterABI } from "./05-init";
 import { RpcProvider, Contract, cairo, hash } from "starknet";
 import {
   classHash as moduleClassHash,
   P256Signer,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 const providerURL = "http://127.0.0.1:5050/rpc";
 const p256PrivateKey =
@@ -31,9 +33,9 @@ const main = async () => {
 
   const publicKeyHash = hash.computeHashOnElements(publicKeyArray);
   const computedAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountlassNames.SmartrAccount,
     publicKeyHash,
-    [moduleClassHash("P256Validator"), "0x4", ...publicKeyArray]
+    [moduleClassHash(moduleClassNames.P256Validator), "0x4", ...publicKeyArray]
   );
 
   // execute the transaction

--- a/experiments/documentation-examples/src/05-get-publickey.ts
+++ b/experiments/documentation-examples/src/05-get-publickey.ts
@@ -3,6 +3,7 @@ import { SmartrAccount } from "@0xknwn/starknet-modular-account";
 import {
   classHash as moduleClassHash,
   P256ValidatorABI,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { init } from "./05-init";
 import { CallData, RpcProvider } from "starknet";
@@ -23,7 +24,7 @@ const main = async () => {
   const moduleCallData = new CallData(P256ValidatorABI);
   const calldata = moduleCallData.compile("get_public_key", {});
   const public_keys = await account.callOnModule(
-    moduleClassHash("P256Validator"),
+    moduleClassHash(moduleClassNames.P256Validator),
     "get_public_key",
     calldata
   );

--- a/experiments/documentation-examples/src/05-init.ts
+++ b/experiments/documentation-examples/src/05-init.ts
@@ -3,6 +3,7 @@ import {
   accountAddress,
   classHash,
   SmartrAccountABI,
+  classNames as accountlassNames,
 } from "@0xknwn/starknet-modular-account";
 import {
   counterAddress as helperCounterAddress,
@@ -19,13 +20,13 @@ export const init = async () => {
   // compute the smartrAccount details
   const smartrSigner = new Signer(smartrAccountPrivateKey);
   const smartrAccountPublicKey = await smartrSigner.getPubKey();
-  const starkValidatorClassHash = classHash("StarkValidator");
+  const starkValidatorClassHash = classHash(accountlassNames.StarkValidator);
   const calldata = new CallData(SmartrAccountABI).compile("constructor", {
     core_validator: starkValidatorClassHash,
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountlassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );

--- a/experiments/documentation-examples/src/05-register-publickey.ts
+++ b/experiments/documentation-examples/src/05-register-publickey.ts
@@ -3,6 +3,7 @@ import { SmartrAccount } from "@0xknwn/starknet-modular-account";
 import {
   classHash as moduleClassHash,
   P256Signer,
+  classNames as moduleClassNames,
 } from "@0xknwn/starknet-module";
 import { cairo } from "starknet";
 import { init } from "./05-init";
@@ -23,7 +24,7 @@ const main = async () => {
     "1",
     "0x3"
   );
-  const module_class_hash = moduleClassHash("P256Validator");
+  const module_class_hash = moduleClassHash(moduleClassNames.P256Validator);
   const signer = new P256Signer(p256PrivateKey);
   const publicKey = await signer.getPubKey();
   const coords = publicKey.slice(2, publicKey.length);

--- a/experiments/documentation-examples/src/05-remove-module.ts
+++ b/experiments/documentation-examples/src/05-remove-module.ts
@@ -1,6 +1,9 @@
 // file src/05-remove-module.ts
 import { SmartrAccount } from "@0xknwn/starknet-modular-account";
-import { classHash } from "@0xknwn/starknet-module";
+import {
+  classHash,
+  classNames as moduleClassNames,
+} from "@0xknwn/starknet-module";
 import { init } from "./05-init";
 import { RpcProvider } from "starknet";
 
@@ -18,15 +21,17 @@ const main = async () => {
     "0x3"
   );
   const { transaction_hash } = await account.removeModule(
-    classHash("P256Validator")
+    classHash(moduleClassNames.P256Validator)
   );
   const receipt = await account.waitForTransaction(transaction_hash);
   console.log("transaction succeeded", receipt.isSuccess());
 
-  const isInstalled = await account.isModule(classHash("P256Validator"));
+  const isInstalled = await account.isModule(
+    classHash(moduleClassNames.P256Validator)
+  );
   console.log(
     "module",
-    classHash("P256Validator"),
+    classHash(moduleClassNames.P256Validator),
     "is installed:",
     isInstalled
   );

--- a/experiments/documentation-examples/src/05-setup.ts
+++ b/experiments/documentation-examples/src/05-setup.ts
@@ -12,11 +12,13 @@ import {
   SmartrAccount,
   deployAccount,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { ABI as ERC20ABI } from "./abi/ERC20";
 import {
   declareClass as helperDeclareClass,
   deployCounter,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 
 const ozAccountAddress =
@@ -39,10 +41,10 @@ const main = async () => {
   );
 
   // declare the classes
-  await declareClass(account, "SmartrAccount");
+  await declareClass(account, accountClassNames.SmartrAccount);
   const { classHash: starkValidatorClassHash } = await declareClass(
     account,
-    "StarkValidator"
+    accountClassNames.StarkValidator
   );
 
   // load ETH
@@ -53,7 +55,7 @@ const main = async () => {
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -80,7 +82,7 @@ const main = async () => {
   );
   const address = await deployAccount(
     smartrAccount,
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -93,7 +95,7 @@ const main = async () => {
   // deploy the Counter contract
   const { classHash: counterClassHash } = await helperDeclareClass(
     account,
-    "Counter"
+    helperClassNames.Counter
   );
   const counter = await deployCounter(account, account.address);
   console.log("Account address:", smartrAccountAddress);

--- a/experiments/documentation-examples/src/06-init.ts
+++ b/experiments/documentation-examples/src/06-init.ts
@@ -3,6 +3,7 @@ import {
   accountAddress,
   classHash,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import {
   counterAddress as helperCounterAddress,
@@ -11,21 +12,21 @@ import {
 
 const ozAccountAddress =
   "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691";
-  const ozAccountPrivateKey = "0x71d7bb07b9a64f6f78ac4c816aff4da9";
-  const smartrAccountPrivateKey = "0x1";
+const ozAccountPrivateKey = "0x71d7bb07b9a64f6f78ac4c816aff4da9";
+const smartrAccountPrivateKey = "0x1";
 
 export { CounterABI };
 export const init = async () => {
   // compute the smartrAccount details
   const smartrSigner = new Signer(smartrAccountPrivateKey);
   const smartrAccountPublicKey = await smartrSigner.getPubKey();
-  const starkValidatorClassHash = classHash("StarkValidator");
+  const starkValidatorClassHash = classHash(accountClassNames.StarkValidator);
   const calldata = new CallData(SmartrAccountABI).compile("constructor", {
     core_validator: starkValidatorClassHash,
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );

--- a/experiments/documentation-examples/src/06-sessionkey-transaction.ts
+++ b/experiments/documentation-examples/src/06-sessionkey-transaction.ts
@@ -1,5 +1,9 @@
 // file src/06-sessionkey-transaction.ts
-import { SmartrAccount, classHash } from "@0xknwn/starknet-modular-account";
+import {
+  SmartrAccount,
+  classHash,
+  classNames as accountClassNames,
+} from "@0xknwn/starknet-modular-account";
 import {
   classHash as sessionkeyClassHash,
   PolicyManager,
@@ -46,12 +50,14 @@ const main = async () => {
   // Step 3: Generate the sessionkey grant request
   // that is an important step to request a session key because that is when
   // the core validator class is registered with the session key module
-  const request = await sessionKeyModule.request(classHash("StarkValidator"));
+  const request = await sessionKeyModule.request(
+    classHash(accountClassNames.StarkValidator)
+  );
   console.log("request", request);
 
   // Step 4: Use the SessionKeyGrantor helper class to sign the request
   const grantor = new SessionKeyGrantor(
-    classHash("StarkValidator"),
+    classHash(accountClassNames.StarkValidator),
     smartrAccountPrivateKey
   );
   const signature = await grantor.sign(sessionKeyModule);
@@ -79,9 +85,8 @@ const main = async () => {
   console.log("currentCounter", currentCounter);
   const call = counter.populate("increment");
   const { transaction_hash } = await smartrAccountWithSessionKey.execute(call);
-  const receipt = await smartrAccountWithSessionKey.waitForTransaction(
-    transaction_hash
-  );
+  const receipt =
+    await smartrAccountWithSessionKey.waitForTransaction(transaction_hash);
   console.log("transaction succeeded", receipt.isSuccess());
   currentCounter = await counter.call("get");
   console.log("currentCounter", currentCounter);

--- a/experiments/documentation-examples/src/06-setup.ts
+++ b/experiments/documentation-examples/src/06-setup.ts
@@ -12,11 +12,13 @@ import {
   SmartrAccount,
   deployAccount,
   SmartrAccountABI,
+  classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { ABI as ERC20ABI } from "./abi/ERC20";
 import {
   declareClass as helperDeclareClass,
   deployCounter,
+  classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
 
 const ozAccountAddress =
@@ -39,10 +41,10 @@ const main = async () => {
   );
 
   // declare the classes
-  await declareClass(account, "SmartrAccount");
+  await declareClass(account, accountClassNames.SmartrAccount);
   const { classHash: starkValidatorClassHash } = await declareClass(
     account,
-    "StarkValidator"
+    accountClassNames.StarkValidator
   );
 
   // load ETH
@@ -53,7 +55,7 @@ const main = async () => {
     args: [smartrAccountPublicKey],
   });
   const smartrAccountAddress = accountAddress(
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -80,7 +82,7 @@ const main = async () => {
   );
   const address = await deployAccount(
     smartrAccount,
-    "SmartrAccount",
+    accountClassNames.SmartrAccount,
     smartrAccountPublicKey,
     calldata
   );
@@ -93,7 +95,7 @@ const main = async () => {
   // deploy the Counter contract
   const { classHash: counterClassHash } = await helperDeclareClass(
     account,
-    "Counter"
+    helperClassNames.Counter
   );
   const counter = await deployCounter(account, account.address);
   console.log("Account address:", smartrAccountAddress);

--- a/experiments/starknet-bootstrap-account/package.json
+++ b/experiments/starknet-bootstrap-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-bootstrap-account",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,8 +13,8 @@
   "author": "0xknwn",
   "license": "MIT",
   "dependencies": {
-    "@0xknwn/starknet-test-helpers": "^0.2.2",
-    "@0xknwn/starknet-modular-account": "^0.2.2"
+    "@0xknwn/starknet-test-helpers": "^0.2.3",
+    "@0xknwn/starknet-modular-account": "^0.2.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",

--- a/experiments/starknet-failed-account/package.json
+++ b/experiments/starknet-failed-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-failed-account",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,8 +13,8 @@
   "author": "0xknwn",
   "license": "MIT",
   "dependencies": {
-    "@0xknwn/starknet-test-helpers": "^0.2.2",
-    "@0xknwn/starknet-modular-account": "^0.2.2"
+    "@0xknwn/starknet-test-helpers": "^0.2.3",
+    "@0xknwn/starknet-modular-account": "^0.2.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet-modular-account",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet-modular-account",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "MIT",
       "workspaces": [
         "experiments/starknet-failed-account",
@@ -33,11 +33,11 @@
       }
     },
     "experiments/starknet-bootstrap-account": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@0xknwn/starknet-modular-account": "^0.2.2",
-        "@0xknwn/starknet-test-helpers": "^0.2.2"
+        "@0xknwn/starknet-modular-account": "^0.2.3",
+        "@0xknwn/starknet-test-helpers": "^0.2.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -50,11 +50,11 @@
       }
     },
     "experiments/starknet-failed-account": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@0xknwn/starknet-modular-account": "^0.2.2",
-        "@0xknwn/starknet-test-helpers": "^0.2.2"
+        "@0xknwn/starknet-modular-account": "^0.2.3",
+        "@0xknwn/starknet-test-helpers": "^0.2.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -5927,10 +5927,10 @@
     },
     "sdks/__tests__/account": {
       "name": "tests-starknet-account",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@0xknwn/starknet-test-helpers": "^0.2.1"
+        "@0xknwn/starknet-test-helpers": "^0.2.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -5944,7 +5944,7 @@
     },
     "sdks/__tests__/helpers": {
       "name": "@0xknwn/starknet-test-helpers",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -5958,10 +5958,10 @@
     },
     "sdks/__tests__/module": {
       "name": "tests-module",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@0xknwn/starknet-test-helpers": "^0.2.1",
+        "@0xknwn/starknet-test-helpers": "^0.2.3",
         "@noble/curves": "^1.4.0"
       },
       "devDependencies": {
@@ -5976,10 +5976,10 @@
     },
     "sdks/__tests__/module-guarded": {
       "name": "tests-module-guarded",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@0xknwn/starknet-test-helpers": "^0.2.1",
+        "@0xknwn/starknet-test-helpers": "^0.2.3",
         "@noble/curves": "^1.4.0"
       },
       "devDependencies": {
@@ -5994,10 +5994,10 @@
     },
     "sdks/__tests__/module-sessionkey": {
       "name": "tests-module-sessionkey",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@0xknwn/starknet-test-helpers": "^0.2.1"
+        "@0xknwn/starknet-test-helpers": "^0.2.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -6011,7 +6011,7 @@
     },
     "sdks/account": {
       "name": "@0xknwn/starknet-modular-account",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -6025,7 +6025,7 @@
     },
     "sdks/module": {
       "name": "@0xknwn/starknet-module",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",
@@ -6039,7 +6039,7 @@
     },
     "sdks/module-sessionkey": {
       "name": "@0xknwn/starknet-module-sessionkey",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-modular-account",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "a modular account for starknet",
   "scripts": {
     "artifacts:artifacts": "cp -R target/dev/smartr_StarkValidator.* target/dev/smartr_GuardedValidator.*  target/dev/smartr_SimpleValidator.* target/dev/smartr_MultisigValidator.* target/dev/smartr_SmartrAccount.* target/dev/smartr_SessionKeyValidator.* target/dev/smartr_EthValidator.* target/dev/smartr_P256Validator.* artifacts/.",

--- a/sdks/__tests__/account/package.json
+++ b/sdks/__tests__/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-starknet-account",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "scripts": {
     "test": "jest --runInBand --verbose"
@@ -8,7 +8,7 @@
   "author": "0xknwn",
   "license": "MIT",
   "dependencies": {
-    "@0xknwn/starknet-test-helpers": "^0.2.1"
+    "@0xknwn/starknet-test-helpers": "^0.2.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",

--- a/sdks/__tests__/helpers/package.json
+++ b/sdks/__tests__/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-test-helpers",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/__tests__/module-guarded/package.json
+++ b/sdks/__tests__/module-guarded/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module-guarded",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "scripts": {
     "test": "jest --runInBand --verbose"
@@ -8,7 +8,7 @@
   "author": "0xknwn",
   "license": "MIT",
   "dependencies": {
-    "@0xknwn/starknet-test-helpers": "^0.2.1",
+    "@0xknwn/starknet-test-helpers": "^0.2.3",
     "@noble/curves": "^1.4.0"
   },
   "devDependencies": {

--- a/sdks/__tests__/module-sessionkey/package.json
+++ b/sdks/__tests__/module-sessionkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module-sessionkey",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "scripts": {
     "test": "jest --runInBand --verbose"
@@ -8,7 +8,7 @@
   "author": "0xknwn",
   "license": "MIT",
   "dependencies": {
-    "@0xknwn/starknet-test-helpers": "^0.2.1"
+    "@0xknwn/starknet-test-helpers": "^0.2.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.20.0",

--- a/sdks/__tests__/module-sessionkey/src/sessionkey_with_root.test.ts
+++ b/sdks/__tests__/module-sessionkey/src/sessionkey_with_root.test.ts
@@ -13,7 +13,10 @@ import {
   STRK,
   classNames as helperClassNames,
 } from "@0xknwn/starknet-test-helpers";
-import { PolicyManager } from "@0xknwn/starknet-module-sessionkey";
+import {
+  PolicyManager,
+  classNames as sessionKeyClassNames,
+} from "@0xknwn/starknet-module-sessionkey";
 import {
   declareClass as declareAccountClass,
   classHash as accountClassHash,
@@ -265,8 +268,13 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareSessionkeyClass(a, "SessionKeyValidator");
-        expect(c.classHash).toEqual(sessionkeyClassHash("SessionKeyValidator"));
+        const c = await declareSessionkeyClass(
+          a,
+          sessionKeyClassNames.SessionKeyValidator
+        );
+        expect(c.classHash).toEqual(
+          sessionkeyClassHash(sessionKeyClassNames.SessionKeyValidator)
+        );
       },
       default_timeout
     );
@@ -278,7 +286,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const { transaction_hash } = await smartrAccount.addModule(
-          sessionkeyClassHash("SessionKeyValidator")
+          sessionkeyClassHash(sessionKeyClassNames.SessionKeyValidator)
         );
         const receipt =
           await smartrAccount.waitForTransaction(transaction_hash);
@@ -294,7 +302,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const output = await smartrAccount.isModule(
-          sessionkeyClassHash("SessionKeyValidator")
+          sessionkeyClassHash(sessionKeyClassNames.SessionKeyValidator)
         );
         expect(output).toBe(true);
       },
@@ -337,7 +345,7 @@ describe.each([data[1]])(
         sessionKeyModule = new SessionKeyModule(
           conf.accounts[1].publicKey,
           smartrAccount.address,
-          sessionkeyClassHash("SessionKeyValidator"),
+          sessionkeyClassHash(sessionKeyClassNames.SessionKeyValidator),
           connectedChain,
           `0x${next_timestamp.toString(16)}`,
           policyManager
@@ -349,7 +357,7 @@ describe.each([data[1]])(
         expect(r.hash).toBe(
           hash_auth_message(
             smartrAccount.address,
-            sessionkeyClassHash("SessionKeyValidator"),
+            sessionkeyClassHash(sessionKeyClassNames.SessionKeyValidator),
             accountClassHash(accountClassNames.StarkValidator),
             conf.accounts[1].publicKey,
             `0x${next_timestamp.toString(16)}`,
@@ -453,7 +461,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const { transaction_hash } = await smartrAccount.removeModule(
-          sessionkeyClassHash("SessionKeyValidator")
+          sessionkeyClassHash(sessionKeyClassNames.SessionKeyValidator)
         );
         const receipt =
           await smartrAccount.waitForTransaction(transaction_hash);
@@ -469,7 +477,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const output = await smartrAccount.isModule(
-          sessionkeyClassHash("SessionKeyValidator")
+          sessionkeyClassHash(sessionKeyClassNames.SessionKeyValidator)
         );
         expect(output).toBe(false);
       },

--- a/sdks/__tests__/module-sessionkey/src/sessionkey_zero_root.test.ts
+++ b/sdks/__tests__/module-sessionkey/src/sessionkey_zero_root.test.ts
@@ -27,6 +27,7 @@ import { RpcProvider, CallData } from "starknet";
 import {
   SessionKeyModule,
   SessionKeyGrantor,
+  classNames as sessionkeyClassNames,
 } from "@0xknwn/starknet-module-sessionkey";
 import { StarkValidatorABI } from "@0xknwn/starknet-modular-account";
 import {
@@ -267,10 +268,16 @@ describe.each([data[1]])(
       async () => {
         const conf = config(env);
         const a = testAccounts(conf)[accountID];
-        const c = await declareSessionkeyClass(a, "SessionKeyValidator", {
-          version: version.declare,
-        });
-        expect(c.classHash).toEqual(sessionkeyClassHash("SessionKeyValidator"));
+        const c = await declareSessionkeyClass(
+          a,
+          sessionkeyClassNames.SessionKeyValidator,
+          {
+            version: version.declare,
+          }
+        );
+        expect(c.classHash).toEqual(
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
+        );
       },
       default_timeout
     );
@@ -282,7 +289,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const { transaction_hash } = await smartrAccount.addModule(
-          sessionkeyClassHash("SessionKeyValidator")
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
         );
         const receipt =
           await smartrAccount.waitForTransaction(transaction_hash);
@@ -298,7 +305,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const output = await smartrAccount.isModule(
-          sessionkeyClassHash("SessionKeyValidator")
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
         );
         expect(output).toBe(true);
       },
@@ -334,7 +341,7 @@ describe.each([data[1]])(
         sessionKeyModule = new SessionKeyModule(
           conf.accounts[1].publicKey,
           smartrAccount.address,
-          sessionkeyClassHash("SessionKeyValidator"),
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator),
           connectedChain,
           `0x${next_timestamp.toString(16)}`
         );
@@ -344,7 +351,7 @@ describe.each([data[1]])(
         expect(r.hash).toBe(
           hash_auth_message(
             smartrAccount.address,
-            sessionkeyClassHash("SessionKeyValidator"),
+            sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator),
             accountClassHash(accountClassNames.StarkValidator),
             conf.accounts[1].publicKey,
             `0x${next_timestamp.toString(16)}`,
@@ -439,7 +446,7 @@ describe.each([data[1]])(
           sessionkey,
         });
         const { transaction_hash } = await smartrAccount.executeOnModule(
-          sessionkeyClassHash("SessionKeyValidator"),
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator),
           "disable_session_key",
           data
         );
@@ -460,7 +467,7 @@ describe.each([data[1]])(
           sessionkey,
         });
         const output = await smartrAccount.callOnModule(
-          sessionkeyClassHash("SessionKeyValidator"),
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator),
           "is_disabled_session_key",
           data
         );
@@ -513,7 +520,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const { transaction_hash } = await smartrAccount.removeModule(
-          sessionkeyClassHash("SessionKeyValidator")
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
         );
         const receipt =
           await smartrAccount.waitForTransaction(transaction_hash);
@@ -529,7 +536,7 @@ describe.each([data[1]])(
           throw new Error("SmartrAccount is not deployed");
         }
         const output = await smartrAccount.isModule(
-          sessionkeyClassHash("SessionKeyValidator")
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
         );
         expect(output).toBe(false);
       },

--- a/sdks/__tests__/module-sessionkey/src/swap.test.ts
+++ b/sdks/__tests__/module-sessionkey/src/swap.test.ts
@@ -25,6 +25,7 @@ import {
   accountAddress,
   hash_auth_message,
   SmartrAccountABI,
+  StarkValidatorABI,
   classNames as accountClassNames,
 } from "@0xknwn/starknet-modular-account";
 import { cairo, RpcProvider, CallData, Contract } from "starknet";
@@ -33,8 +34,8 @@ import {
   SessionKeyGrantor,
   declareClass as declareSessionkeyClass,
   classHash as sessionkeyClassHash,
+  classNames as sessionkeyClassNames,
 } from "@0xknwn/starknet-module-sessionkey";
-import { StarkValidatorABI } from "@0xknwn/starknet-modular-account";
 import { data } from "./data.fixture";
 
 describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
@@ -307,10 +308,16 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
     async () => {
       const conf = config(env);
       const a = testAccounts(conf)[accountID];
-      const c = await declareSessionkeyClass(a, "SessionKeyValidator", {
-        version: version.declare,
-      });
-      expect(c.classHash).toEqual(sessionkeyClassHash("SessionKeyValidator"));
+      const c = await declareSessionkeyClass(
+        a,
+        sessionkeyClassNames.SessionKeyValidator,
+        {
+          version: version.declare,
+        }
+      );
+      expect(c.classHash).toEqual(
+        sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
+      );
     },
     default_timeout
   );
@@ -322,7 +329,7 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       const { transaction_hash } = await smartrAccount.addModule(
-        sessionkeyClassHash("SessionKeyValidator")
+        sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
@@ -337,7 +344,7 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       const output = await smartrAccount.isModule(
-        sessionkeyClassHash("SessionKeyValidator")
+        sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
       );
       expect(output).toBe(true);
     },
@@ -358,7 +365,7 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
       sessionKeyModule = new SessionKeyModule(
         conf.accounts[1].publicKey,
         smartrAccount.address,
-        sessionkeyClassHash("SessionKeyValidator"),
+        sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator),
         connectedChain,
         `0x${next_timestamp.toString(16)}`
       );
@@ -368,7 +375,7 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
       expect(r.hash).toBe(
         hash_auth_message(
           smartrAccount.address,
-          sessionkeyClassHash("SessionKeyValidator"),
+          sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator),
           accountClassHash(accountClassNames.StarkValidator),
           conf.accounts[1].publicKey,
           `0x${next_timestamp.toString(16)}`,
@@ -480,7 +487,7 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       const { transaction_hash } = await smartrAccount.removeModule(
-        sessionkeyClassHash("SessionKeyValidator")
+        sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
       );
       const receipt = await smartrAccount.waitForTransaction(transaction_hash);
       expect(receipt.isSuccess()).toBe(true);
@@ -495,7 +502,7 @@ describe.each([data[1]])("sessionkey swap", ({ fees, accountID, version }) => {
         throw new Error("SmartrAccount is not deployed");
       }
       const output = await smartrAccount.isModule(
-        sessionkeyClassHash("SessionKeyValidator")
+        sessionkeyClassHash(sessionkeyClassNames.SessionKeyValidator)
       );
       expect(output).toBe(false);
     },

--- a/sdks/__tests__/module/package.json
+++ b/sdks/__tests__/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "scripts": {
     "test": "jest --runInBand --verbose"
@@ -8,7 +8,7 @@
   "author": "0xknwn",
   "license": "MIT",
   "dependencies": {
-    "@0xknwn/starknet-test-helpers": "^0.2.1",
+    "@0xknwn/starknet-test-helpers": "^0.2.3",
     "@noble/curves": "^1.4.0"
   },
   "devDependencies": {

--- a/sdks/account/package.json
+++ b/sdks/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-modular-account",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/module-sessionkey/package.json
+++ b/sdks/module-sessionkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-module-sessionkey",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/module-sessionkey/src/class.ts
+++ b/sdks/module-sessionkey/src/class.ts
@@ -9,6 +9,9 @@ import { Buffer } from "buffer";
 import { data as SessionKeyValidatorContract } from "./artifacts/SessionKeyValidator-contract";
 import { data as SessionKeyValidatorCompiled } from "./artifacts/SessionKeyValidator-compiled";
 
+export enum classNames {
+  SessionKeyValidator = "SessionKeyValidator",
+}
 /**
  * Computes the hash of the requested class that is part of the
  * 0xknwn/starknet-modular-account project.
@@ -19,11 +22,11 @@ import { data as SessionKeyValidatorCompiled } from "./artifacts/SessionKeyValid
  *
  */
 export const classHash = (
-  className: "SessionKeyValidator" = "SessionKeyValidator"
+  className: classNames = classNames.SessionKeyValidator
 ) => {
   let contract: string = "";
   switch (className) {
-    case "SessionKeyValidator":
+    case classNames.SessionKeyValidator:
       contract = SessionKeyValidatorContract;
       break;
     default:
@@ -51,7 +54,7 @@ export const classHash = (
  */
 export const declareClass = async (
   account: Account,
-  className: "SessionKeyValidator",
+  className: classNames.SessionKeyValidator,
   details?: UniversalDetails
 ) => {
   const HelperClassHash = classHash(className);

--- a/sdks/module/package.json
+++ b/sdks/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xknwn/starknet-module",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

move documentation-examples to SDKs v0.2.2 and prepare v0.2.3

## Impacts on the signers

N/A

## Changes

- Update dependencies in documentation-examples to match the updated version
- Add enum to sessionkey-module and prepare to publish as v0.2.3

## Checklist:

- [ ] Link the associated issue
- [x] Perform a self-review of the code
- [x] Rebase to the head of the `develop` branch from 0xknow/starknet-modular-account
- [ ] Document the changes in code
- [ ] Make sure the code is properly formatted by running `scarb fmt`
- [ ] Add unit tests with starknet foundry
- [x] Add integration tests with starknet.js and jest
- [x] Pass all the tests
