### PR TITLE
prepare v0.2.7

### DIFF
--- a/.github/workflows/snfoundry.yml
+++ b/.github/workflows/snfoundry.yml
@@ -34,6 +34,7 @@ jobs:
         uses: software-mansion/setup-scarb@22f50f68eb6ffacfc173786dab19aa7d49b43441 # v1
         with:
           scarb-lock: ./starknet-modular-account/Scarb.lock
+          scarb-version: "2.9.3"
 
       - name: Run tests
         run: scarb test

--- a/.github/workflows/snfoundry.yml
+++ b/.github/workflows/snfoundry.yml
@@ -2,15 +2,15 @@ name: snfoundry
 on:
   pull_request:
     branches:
-      - '**'
+      - "**"
     paths:
-      - '**'
-      - '!docs/*'
+      - "**"
+      - "!docs/*"
   push:
     branches:
-      - 'develop'
+      - "develop"
     paths:
-      - '**'
+      - "**"
 
 permissions:
   contents: read
@@ -25,10 +25,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
-          cache: 'npm'
+          node-version: "22.x"
+          cache: "npm"
       - name: Setup Starknet Foundry
-        uses: foundry-rs/setup-snfoundry@bd5fc266ba0ce7e352b01dd7eaacc0fbb6145d17 # v3
+        uses: foundry-rs/setup-snfoundry@ee00ea3f026379008ca40a54448d4059233d06cc # v4
 
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@22f50f68eb6ffacfc173786dab19aa7d49b43441 # v1

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -72,15 +72,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:b9550f5c921502be3e240e83aa9e2dc6ee63ae76bfecee082b7a15bead0460c0"
+checksum = "sha256:9dbb114f853decc27b2d6d53e2ddd207217ce63c2d24a47c5c48d5f475b0b9a5"
 
 [[package]]
 name = "snforge_std"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:9f38c6c376447cfe225c5869905122f6a64bc301f5872c7855d2abe6e9c0a1da"
+checksum = "sha256:f5702c4a6d54e3563b4aa78c834de6ddcf18ef8ca8fd35dc1bceb7ece58e9571"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -6,7 +6,7 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.9.2"
+starknet = "2.9.3"
 openzeppelin_account = "0.20.0"
 openzeppelin_introspection = "0.20.0"
 openzeppelin_token = "0.20.0"
@@ -16,8 +16,8 @@ openzeppelin_security = "0.20.0"
 openzeppelin_utils = "0.20.0"
 
 [dev-dependencies]
-snforge_std = "0.36.0"
-assert_macros = "2.9.2"
+snforge_std = "0.37.0"
+assert_macros = "2.9.3"
 
 [[target.starknet-contract]]
 sierra = true

--- a/experiments/starknet-bootstrap-account/package.json
+++ b/experiments/starknet-bootstrap-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-bootstrap-account",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/experiments/starknet-failed-account/package.json
+++ b/experiments/starknet-failed-account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-failed-account",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet-modular-account",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "a modular account for starknet",
   "scripts": {
     "artifacts:artifacts": "cp -R target/dev/smartr_StarkValidator.* target/dev/smartr_GuardedValidator.*  target/dev/smartr_SimpleValidator.* target/dev/smartr_MultisigValidator.* target/dev/smartr_SmartrAccount.* target/dev/smartr_SessionKeyValidator.* target/dev/smartr_EthValidator.* target/dev/smartr_P256Validator.* artifacts/.",

--- a/sdks/__tests__/account/package.json
+++ b/sdks/__tests__/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-starknet-account",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "scripts": {
     "lint": "eslint src",

--- a/sdks/__tests__/helpers/package.json
+++ b/sdks/__tests__/helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xknwn/starknet-test-helpers",
   "private": false,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/__tests__/module-guarded/package.json
+++ b/sdks/__tests__/module-guarded/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module-guarded",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "scripts": {
     "lint": "eslint src",

--- a/sdks/__tests__/module-sessionkey/package.json
+++ b/sdks/__tests__/module-sessionkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module-sessionkey",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "scripts": {
     "lint": "eslint src",

--- a/sdks/__tests__/module/package.json
+++ b/sdks/__tests__/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tests-module",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "scripts": {
     "lint": "eslint src",

--- a/sdks/account/package.json
+++ b/sdks/account/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xknwn/starknet-modular-account",
   "private": false,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/module-sessionkey/package.json
+++ b/sdks/module-sessionkey/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xknwn/starknet-module-sessionkey",
   "private": false,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/module/package.json
+++ b/sdks/module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@0xknwn/starknet-module",
   "private": false,
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

prepare for v0.2.7

## Changes

This PR includes a number of changes, including

- The availability of artifacts and class hashes in a separate package
- Fix for the experiments
- Upgrade to cairo 2.9.3 which impacts the compiled code
- Removal of V0, V1 and V2 of the protocol and, as a result, removal of ETH payments

## Checklist:

- [ ] Link the associated issue
- [x] Perform a self-review of the code
- [x] Rebase to the head of the `develop` branch from 0xknow/starknet-modular-account
- [ ] Document the changes in code
- [ ] Make sure the code is properly formatted by running `scarb fmt`
- [x] Add unit tests with starknet foundry
- [ ] Add integration tests with starknet.js and jest
- [x] Pass all the tests
